### PR TITLE
Add roulette wheel table for character selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,13 @@
         </header>
 
         <section class="roulette">
+            <div class="roulette__table" aria-hidden="true">
+                <span class="roulette__table-label">Charakter-Roulette</span>
+                <div class="roulette__wheel-wrapper">
+                    <canvas id="rouletteCanvas" width="360" height="360" class="roulette__wheel" role="img" aria-label="Roulette Tisch mit allen Charakteren"></canvas>
+                    <div class="roulette__pointer" aria-hidden="true"></div>
+                </div>
+            </div>
             <div class="roulette__item-box" aria-live="polite" aria-atomic="true">
                 <span class="roulette__label">Nächster Charakter</span>
                 <div id="spinDisplay" class="roulette__display">?</div>

--- a/script.js
+++ b/script.js
@@ -32,15 +32,211 @@ const assignmentList = document.querySelector("#assignmentList");
 const assignmentTemplate = document.querySelector("#assignmentTemplate");
 const feedback = document.querySelector("#feedback");
 const remaining = document.querySelector("#remaining");
+const rouletteCanvas = document.querySelector("#rouletteCanvas");
+const wheelContext = rouletteCanvas?.getContext("2d");
+
+const WHEEL_BASE_SIZE = 360;
+const wheelColors = [
+  "#ff6b6b",
+  "#ffd93d",
+  "#6ef2b4",
+  "#4dabf7",
+  "#b197fc",
+  "#ffa94d",
+  "#74c0fc",
+  "#f783ac",
+];
+
+let rotation = 0;
+let isSpinning = false;
+let activeFrame = null;
 
 let availableCharacters = [...characters];
 const assignments = new Map();
 
+function setupWheelCanvas() {
+  if (!rouletteCanvas || !wheelContext) return;
+
+  const devicePixelRatio = window.devicePixelRatio || 1;
+  rouletteCanvas.width = WHEEL_BASE_SIZE * devicePixelRatio;
+  rouletteCanvas.height = WHEEL_BASE_SIZE * devicePixelRatio;
+  rouletteCanvas.style.width = "100%";
+  rouletteCanvas.style.height = "100%";
+  wheelContext.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+  drawWheel();
+}
+
+function drawWheel(highlightedCharacter = null) {
+  if (!rouletteCanvas || !wheelContext) return;
+
+  const size = WHEEL_BASE_SIZE;
+  const radius = size / 2 - 18;
+  const center = size / 2;
+  const innerRadius = 46;
+  const totalSegments = characters.length;
+  const anglePerSegment = (Math.PI * 2) / totalSegments;
+
+  wheelContext.clearRect(0, 0, size, size);
+
+  wheelContext.save();
+  wheelContext.translate(center, center);
+  wheelContext.rotate(rotation - Math.PI / 2);
+
+  for (let i = 0; i < totalSegments; i++) {
+    const character = characters[i];
+    const startAngle = i * anglePerSegment;
+    const endAngle = startAngle + anglePerSegment;
+    const isAvailable = availableCharacters.includes(character);
+    const isHighlighted = highlightedCharacter && character === highlightedCharacter;
+    const baseColor = wheelColors[i % wheelColors.length];
+    const fillColor = isAvailable ? baseColor : "rgba(80, 84, 128, 0.5)";
+
+    wheelContext.beginPath();
+    wheelContext.moveTo(0, 0);
+    wheelContext.arc(0, 0, radius, startAngle, endAngle);
+    wheelContext.closePath();
+    wheelContext.fillStyle = fillColor;
+    wheelContext.fill();
+
+    if (isHighlighted) {
+      wheelContext.save();
+      wheelContext.clip();
+      const glow = wheelContext.createRadialGradient(0, 0, radius * 0.2, 0, 0, radius);
+      glow.addColorStop(0, "rgba(255, 255, 255, 0.35)");
+      glow.addColorStop(1, "rgba(255, 255, 255, 0)");
+      wheelContext.fillStyle = glow;
+      wheelContext.fillRect(-radius, -radius, radius * 2, radius * 2);
+      wheelContext.restore();
+    }
+
+    wheelContext.strokeStyle = "rgba(6, 9, 30, 0.7)";
+    wheelContext.lineWidth = 2;
+    wheelContext.stroke();
+
+    wheelContext.save();
+    wheelContext.rotate(startAngle + anglePerSegment / 2);
+    wheelContext.translate(radius - 28, 0);
+    wheelContext.rotate(Math.PI / 2);
+    wheelContext.fillStyle = isAvailable ? "#f7f8ff" : "rgba(247, 248, 255, 0.35)";
+    wheelContext.font = "600 13px 'Rubik', sans-serif";
+    wheelContext.textAlign = "center";
+    wheelContext.textBaseline = "middle";
+    wheelContext.fillText(character.name, 0, 0);
+    wheelContext.restore();
+  }
+
+  wheelContext.restore();
+
+  wheelContext.save();
+  wheelContext.translate(center, center);
+  wheelContext.beginPath();
+  wheelContext.arc(0, 0, innerRadius, 0, Math.PI * 2);
+  wheelContext.fillStyle = "rgba(12, 15, 45, 0.92)";
+  wheelContext.fill();
+  wheelContext.lineWidth = 4;
+  wheelContext.strokeStyle = "rgba(255, 255, 255, 0.18)";
+  wheelContext.stroke();
+
+  const centerGradient = wheelContext.createRadialGradient(0, 0, 4, 0, 0, innerRadius);
+  centerGradient.addColorStop(0, "rgba(255, 255, 255, 0.55)");
+  centerGradient.addColorStop(1, "rgba(255, 255, 255, 0)");
+  wheelContext.fillStyle = centerGradient;
+  wheelContext.fill();
+  wheelContext.restore();
+}
+
+function normalizeAngle(angle) {
+  const tau = Math.PI * 2;
+  return ((angle % tau) + tau) % tau;
+}
+
+function targetRotationForCharacter(character) {
+  const totalSegments = characters.length;
+  const index = characters.indexOf(character);
+  const anglePerSegment = (Math.PI * 2) / totalSegments;
+  const segmentCenter = index * anglePerSegment + anglePerSegment / 2;
+  const desired = Math.PI / 2 - segmentCenter;
+  const current = normalizeAngle(rotation);
+  let delta = desired - current;
+  if (delta <= 0) {
+    delta += Math.PI * 2;
+  }
+  const extraSpins = 3 + Math.floor(Math.random() * 2);
+  return rotation + extraSpins * Math.PI * 2 + delta;
+}
+
+function animateRotation(targetRotation, duration = 4200) {
+  return new Promise((resolve) => {
+    const startRotation = rotation;
+    const totalChange = targetRotation - startRotation;
+    const startTime = performance.now();
+
+    function frame(now) {
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = easeOutQuad(progress);
+      rotation = startRotation + totalChange * eased;
+      drawWheel();
+      if (progress < 1) {
+        activeFrame = requestAnimationFrame(frame);
+      } else {
+        activeFrame = null;
+        rotation = normalizeAngle(rotation);
+        drawWheel();
+        resolve();
+      }
+    }
+
+    if (activeFrame) {
+      cancelAnimationFrame(activeFrame);
+    }
+
+    activeFrame = requestAnimationFrame(frame);
+  });
+}
+
+async function spinWheel(finalCharacter) {
+  if (!rouletteCanvas || !wheelContext) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 1000);
+    });
+  }
+
+  isSpinning = true;
+  spinDisplay.classList.add("is-spinning");
+  const shuffleInterval = setInterval(() => {
+    const preview = pickRandomCharacter();
+    if (preview) {
+      spinDisplay.textContent = preview.name;
+    }
+  }, 90);
+
+  const target = targetRotationForCharacter(finalCharacter);
+  try {
+    await animateRotation(target);
+  } finally {
+    clearInterval(shuffleInterval);
+  }
+
+  drawWheel(finalCharacter);
+  spinDisplay.classList.remove("is-spinning");
+  spinDisplay.classList.add("is-final");
+  spinDisplay.innerHTML = `<span class="display__name">${finalCharacter.name}</span><span class="display__tag">${finalCharacter.tag}</span>`;
+  setTimeout(() => spinDisplay.classList.remove("is-final"), 1200);
+  isSpinning = false;
+}
+
 function updateRemainingText() {
   if (availableCharacters.length === 0) {
     remaining.textContent = "Alle Charaktere wurden vergeben!";
+    assignButton.disabled = true;
+    playerNameInput.disabled = true;
   } else {
     remaining.textContent = `${availableCharacters.length} Charaktere sind noch im Item-Block.`;
+    if (!isSpinning) {
+      assignButton.disabled = false;
+      playerNameInput.disabled = false;
+    }
   }
 }
 
@@ -71,53 +267,11 @@ function pickRandomCharacter() {
 
 function removeCharacter(target) {
   availableCharacters = availableCharacters.filter((character) => character !== target);
+  drawWheel();
 }
 
 function easeOutQuad(t) {
   return t * (2 - t);
-}
-
-function spinThroughCharacters(finalCharacter) {
-  const totalSpins = 26;
-  const baseDelay = 60;
-  const maxAdditionalDelay = 150;
-
-  spinDisplay.classList.add("is-spinning");
-  assignButton.disabled = true;
-  playerNameInput.disabled = true;
-
-  for (let i = 0; i < totalSpins; i++) {
-    const progress = i / (totalSpins - 1);
-    const eased = easeOutQuad(progress);
-    const delay = baseDelay * i + maxAdditionalDelay * eased * i * 0.35;
-
-    setTimeout(() => {
-      const current = i === totalSpins - 1 ? finalCharacter : pickRandomCharacter();
-      updateSpinDisplay(current, i === totalSpins - 1);
-    }, delay);
-  }
-
-  const totalDuration = baseDelay * totalSpins + maxAdditionalDelay * easeOutQuad(1) * totalSpins * 0.35;
-
-  setTimeout(() => {
-    spinDisplay.classList.remove("is-spinning");
-    spinDisplay.classList.add("is-final");
-    setTimeout(() => spinDisplay.classList.remove("is-final"), 1200);
-    assignButton.disabled = false;
-    playerNameInput.disabled = false;
-  }, totalDuration + 80);
-
-  return totalDuration;
-}
-
-function updateSpinDisplay(character, isFinal = false) {
-  if (isFinal) {
-    spinDisplay.innerHTML = `<span class="display__name">${character.name}</span><span class="display__tag">${character.tag}</span>`;
-    spinDisplay.classList.add("is-final");
-  } else {
-    spinDisplay.textContent = character.name;
-    spinDisplay.classList.remove("is-final");
-  }
 }
 
 function addAssignment(playerName, character) {
@@ -126,7 +280,11 @@ function addAssignment(playerName, character) {
   assignmentList.append(card);
 }
 
-function handleAssignment() {
+async function handleAssignment() {
+  if (isSpinning) {
+    return;
+  }
+
   const rawName = playerNameInput.value.trim();
 
   if (!rawName) {
@@ -145,18 +303,28 @@ function handleAssignment() {
   }
 
   const chosenCharacter = pickRandomCharacter();
-  const animationDuration = spinThroughCharacters(chosenCharacter);
+  assignButton.disabled = true;
+  playerNameInput.disabled = true;
+  spinDisplay.textContent = "...";
+  spinDisplay.classList.remove("is-final");
 
   showFeedback("Item-Block wird geöffnet...", true);
 
-  setTimeout(() => {
-    removeCharacter(chosenCharacter);
-    addAssignment(rawName, chosenCharacter);
-    updateRemainingText();
-    showFeedback(`${rawName} erhält ${chosenCharacter.name}!`, true);
-    playerNameInput.value = "";
+  await spinWheel(chosenCharacter);
+
+  removeCharacter(chosenCharacter);
+  addAssignment(rawName, chosenCharacter);
+  updateRemainingText();
+  showFeedback(`${rawName} erhält ${chosenCharacter.name}!`, true);
+  playerNameInput.value = "";
+  if (availableCharacters.length > 0) {
     playerNameInput.focus();
-  }, animationDuration + 120);
+  }
+
+  if (availableCharacters.length === 0) {
+    spinDisplay.textContent = "✔";
+    spinDisplay.classList.remove("is-final");
+  }
 }
 
 assignButton.addEventListener("click", handleAssignment);
@@ -167,4 +335,6 @@ playerNameInput.addEventListener("keydown", (event) => {
   }
 });
 
+setupWheelCanvas();
+window.addEventListener("resize", setupWheelCanvas);
 updateRemainingText();

--- a/style.css
+++ b/style.css
@@ -79,6 +79,87 @@ body::before {
     gap: 1.5rem;
 }
 
+.roulette__table {
+    position: relative;
+    display: grid;
+    justify-items: center;
+    gap: 1.2rem;
+    padding: clamp(1.5rem, 4vw, 2.5rem);
+    background: radial-gradient(circle at 50% 20%, rgba(255, 255, 255, 0.18), transparent 60%),
+        linear-gradient(160deg, rgba(21, 25, 70, 0.95), rgba(10, 12, 42, 0.92));
+    border-radius: 24px;
+    border: 2px solid rgba(255, 255, 255, 0.1);
+    box-shadow: inset 0 0 25px rgba(0, 0, 0, 0.45), 0 24px 40px rgba(0, 0, 0, 0.35);
+}
+
+.roulette__table::after {
+    content: "";
+    position: absolute;
+    inset: 14px;
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    pointer-events: none;
+}
+
+.roulette__table-label {
+    font-family: "Press Start 2P", sans-serif;
+    font-size: clamp(0.65rem, 1.6vw, 0.8rem);
+    letter-spacing: 0.24rem;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.roulette__wheel-wrapper {
+    position: relative;
+    display: grid;
+    place-items: center;
+    width: min(360px, 70vw);
+    aspect-ratio: 1/1;
+}
+
+.roulette__wheel-wrapper::before {
+    content: "";
+    position: absolute;
+    inset: 6%;
+    border-radius: 50%;
+    border: 10px solid rgba(255, 255, 255, 0.08);
+    box-shadow:
+        inset 0 0 25px rgba(0, 0, 0, 0.65),
+        0 0 35px rgba(0, 0, 0, 0.35);
+    pointer-events: none;
+    z-index: 1;
+}
+
+.roulette__wheel {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background: radial-gradient(circle at center, rgba(0, 0, 0, 0.5), transparent 65%);
+    box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.6), 0 0 35px rgba(0, 0, 0, 0.35);
+    position: relative;
+    z-index: 0;
+}
+
+.roulette__pointer {
+    position: absolute;
+    top: -12px;
+    width: 34px;
+    height: 48px;
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+    background: linear-gradient(145deg, var(--primary), var(--primary-dark));
+    border: 2px solid rgba(255, 255, 255, 0.5);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.45);
+    z-index: 3;
+}
+
+.roulette__pointer::after {
+    content: "";
+    position: absolute;
+    inset: 40% 28%;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.65);
+}
+
 .roulette__item-box {
     position: relative;
     background: linear-gradient(145deg, rgba(41, 46, 94, 0.9), rgba(19, 22, 54, 0.85));


### PR DESCRIPTION
## Summary
- add a dedicated roulette table section with a canvas-based wheel and pointer styling
- animate the wheel spin and character preview to choose players via a visual roulette experience
- harden the assignment flow by disabling controls during spins and refreshing availability text

## Testing
- Manual verification: python3 -m http.server 8000 and load the page in a browser

------
https://chatgpt.com/codex/tasks/task_e_68e1161030d8832d9d3304d3528cb916