### PR TITLE
Replace roulette with icon-based character selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,35 +12,37 @@
 <body>
     <main class="app">
         <header class="app__header">
-            <h1 class="app__title">Mario Kart Charakter Roulette</h1>
-            <p class="app__subtitle">Trage deinen Namen ein, drücke auf das Item und lass den Zufall entscheiden!</p>
+            <h1 class="app__title">Mario Kart Charakterauswahl</h1>
+            <p class="app__subtitle">Trage deinen Namen ein, starte den Zufall und erhalte deinen Charakter inklusive Icon!</p>
         </header>
 
-        <section class="roulette">
-            <div class="roulette__table" aria-hidden="true">
-                <span class="roulette__table-label">Charakter-Roulette</span>
-                <div class="roulette__wheel-wrapper">
-                    <canvas id="rouletteCanvas" width="360" height="360" class="roulette__wheel" role="img" aria-label="Roulette Tisch mit allen Charakteren"></canvas>
-                    <div class="roulette__pointer" aria-hidden="true"></div>
-                </div>
-            </div>
-            <div class="roulette__item-box" aria-live="polite" aria-atomic="true">
-                <span class="roulette__label">Nächster Charakter</span>
-                <div id="spinDisplay" class="roulette__display">?</div>
-            </div>
-            <div class="roulette__controls">
+        <section class="controls" aria-live="polite">
+            <div class="controls__form">
                 <label class="input__label" for="playerName">Spielername</label>
-                <input type="text" id="playerName" class="input" placeholder="z.B. Lightning Lisa">
-                <button id="assignButton" class="button">
-                    <span class="button__icon" aria-hidden="true">🎲</span>
-                    Zufall starten
-                </button>
+                <div class="controls__inputs">
+                    <input type="text" id="playerName" class="input" placeholder="z.&nbsp;B. Rainbow Raser">
+                    <button id="assignButton" class="button">
+                        <span class="button__icon" aria-hidden="true">🎲</span>
+                        Zufall starten
+                    </button>
+                </div>
+                <p id="feedback" class="feedback" role="status"></p>
             </div>
-            <p id="feedback" class="feedback" role="status"></p>
-            <p id="remaining" class="remaining"></p>
+            <div class="preview" aria-live="polite" aria-atomic="true">
+                <span class="preview__label">Zugewiesener Charakter</span>
+                <div id="spinDisplay" class="preview__display">
+                    <span class="preview__placeholder">?</span>
+                </div>
+                <p id="remaining" class="remaining"></p>
+            </div>
         </section>
 
-        <section class="assignments" aria-live="polite">
+        <section class="character-overview">
+            <h2 class="character-overview__title">Verfügbare Charaktere</h2>
+            <ul id="characterGrid" class="character-grid"></ul>
+        </section>
+
+        <section class="assignments">
             <h2 class="assignments__title">Bisherige Zuweisungen</h2>
             <ul id="assignmentList" class="assignment-list"></ul>
         </section>
@@ -48,11 +50,11 @@
 
     <template id="assignmentTemplate">
         <li class="assignment-card">
-            <div class="assignment-card__info">
-                <span class="assignment-card__player"></span>
-                <span class="assignment-card__tagline"></span>
+            <span class="assignment-card__player"></span>
+            <div class="assignment-card__character">
+                <span class="assignment-card__name"></span>
+                <img class="assignment-card__icon" alt="">
             </div>
-            <span class="assignment-card__character"></span>
         </li>
     </template>
 

--- a/script.js
+++ b/script.js
@@ -1,31 +1,84 @@
 const characters = [
-  { name: "Mario", tag: "Der Allrounder" },
-  { name: "Luigi", tag: "Grüner Blitz" },
-  { name: "Peach", tag: "Königliche Power" },
-  { name: "Daisy", tag: "Blumiger Sprint" },
-  { name: "Rosalina", tag: "Sternenglanz" },
-  { name: "Yoshi", tag: "Turbo Dino" },
-  { name: "Toad", tag: "Pilz-Rakete" },
-  { name: "Toadette", tag: "Pilz-Prinzessin" },
-  { name: "Bowser", tag: "Panzersprint" },
-  { name: "Bowser Jr.", tag: "Chaos Kid" },
-  { name: "Donkey Kong", tag: "Bananen-Boost" },
-  { name: "Diddy Kong", tag: "Fass-Boost" },
-  { name: "Wario", tag: "Goldgräber" },
-  { name: "Waluigi", tag: "Schabernack" },
-  { name: "Koopa", tag: "Panzer-Drifter" },
-  { name: "Shy Guy", tag: "Masken-Mystery" },
-  { name: "Baby Mario", tag: "Mini-Macht" },
-  { name: "Baby Peach", tag: "Kindskopf-Kick" },
-  { name: "Baby Luigi", tag: "Nano Nitro" },
-  { name: "Baby Daisy", tag: "Windel-Drift" },
-  { name: "Metal Mario", tag: "Stahl-Speed" },
-  { name: "King Boo", tag: "Spuk-Sprint" },
-  { name: "Petey Piranha", tag: "Pflanzen-Power" },
-  { name: "Link", tag: "Hylianer Hit" },
-  { name: "Isabelle", tag: "Tierische Turbo" },
-  { name: "Inkling Girl", tag: "Farbenrausch" },
-  { name: "Inkling Boy", tag: "Spritz-Slalom" }
+  { name: "Mii", icon: "Charakter-Icons/Mii_MK8.png" },
+  { name: "Shy Guy (Black)", icon: "Charakter-Icons/MK8_Black_Shy_Guy_Icon.png" },
+  { name: "Yoshi (Black)", icon: "Charakter-Icons/MK8_Black_Yoshi_Icon.png" },
+  { name: "Shy Guy (Blue)", icon: "Charakter-Icons/MK8_Blue_Shy_Guy_Icon.png" },
+  { name: "Yoshi (Blue)", icon: "Charakter-Icons/MK8_Blue_Yoshi_Icon.png" },
+  { name: "Bowser Jr.", icon: "Charakter-Icons/MK8_Bowser_Jr_Icon.png" },
+  { name: "Shy Guy (Green)", icon: "Charakter-Icons/MK8_Green_Shy_Guy_Icon.png" },
+  { name: "Shy Guy (Light-Blue)", icon: "Charakter-Icons/MK8_Light-Blue_Shy_Guy_Icon.png" },
+  { name: "Yoshi (Light-Blue)", icon: "Charakter-Icons/MK8_Light-Blue_Yoshi_Icon.png" },
+  { name: "Shy Guy (Orange)", icon: "Charakter-Icons/MK8_Orange_Shy_Guy_Icon.png" },
+  { name: "Yoshi (Orange)", icon: "Charakter-Icons/MK8_Orange_Yoshi_Icon.png" },
+  { name: "Shy Guy (Pink)", icon: "Charakter-Icons/MK8_Pink_Shy_Guy_Icon.png" },
+  { name: "Yoshi (Pink)", icon: "Charakter-Icons/MK8_Pink_Yoshi_Icon.png" },
+  { name: "Yoshi (Red)", icon: "Charakter-Icons/MK8_Red_Yoshi_Icon.png" },
+  { name: "Shy Guy (White)", icon: "Charakter-Icons/MK8_White_Shy_Guy_Icon.png" },
+  { name: "Yoshi (White)", icon: "Charakter-Icons/MK8_White_Yoshi_Icon.png" },
+  { name: "Shy Guy (Yellow)", icon: "Charakter-Icons/MK8_Yellow_Shy_Guy_Icon.png" },
+  { name: "Yoshi (Yellow)", icon: "Charakter-Icons/MK8_Yellow_Yoshi_Icon.png" },
+  { name: "Birdo (Black)", icon: "Charakter-Icons/MK8D_Birdo_Black_Icon.png" },
+  { name: "Birdo (Blue)", icon: "Charakter-Icons/MK8D_Birdo_Blue_Icon.png" },
+  { name: "Birdo (Green)", icon: "Charakter-Icons/MK8D_Birdo_Green_Icon.png" },
+  { name: "Birdo", icon: "Charakter-Icons/MK8D_Birdo_Icon.png" },
+  { name: "Birdo (Light-Blue)", icon: "Charakter-Icons/MK8D_Birdo_Light-Blue_Icon.png" },
+  { name: "Birdo (Orange)", icon: "Charakter-Icons/MK8D_Birdo_Orange_Icon.png" },
+  { name: "Birdo (Red)", icon: "Charakter-Icons/MK8D_Birdo_Red_Icon.png" },
+  { name: "Birdo (White)", icon: "Charakter-Icons/MK8D_Birdo_White_Icon.png" },
+  { name: "Birdo (Yellow)", icon: "Charakter-Icons/MK8D_Birdo_Yellow_Icon.png" },
+  { name: "Link (BotW)", icon: "Charakter-Icons/MK8D_BotW_Link_Icon.png" },
+  { name: "Inkling (Cyan)", icon: "Charakter-Icons/MK8D_Cyan_Inkling_Icon.png" },
+  { name: "Inkling (Green)", icon: "Charakter-Icons/MK8D_Green_Inkling_Icon.png" },
+  { name: "Inkling (Pink)", icon: "Charakter-Icons/MK8D_Pink_Inkling_Icon.png" },
+  { name: "Inkling (Purple)", icon: "Charakter-Icons/MK8D_Purple_Inkling_Icon.png" },
+  { name: "Baby Daisy", icon: "Charakter-Icons/MK8DX_Baby_Daisy_Icon.png" },
+  { name: "Baby Luigi", icon: "Charakter-Icons/MK8DX_Baby_Luigi_Icon.png" },
+  { name: "Baby Mario", icon: "Charakter-Icons/MK8DX_Baby_Mario_Icon.png" },
+  { name: "Baby Peach", icon: "Charakter-Icons/MK8DX_Baby_Peach_Icon.png" },
+  { name: "Baby Rosalina", icon: "Charakter-Icons/MK8DX_Baby_Rosalina_Icon.png" },
+  { name: "Bowser", icon: "Charakter-Icons/MK8DX_Bowser_Icon.png" },
+  { name: "Cat Peach", icon: "Charakter-Icons/MK8DX_Cat_Peach_Icon.png" },
+  { name: "Daisy", icon: "Charakter-Icons/MK8DX_Daisy_Icon.png" },
+  { name: "Diddy Kong", icon: "Charakter-Icons/MK8DX_Diddy_Kong_Icon.png" },
+  { name: "Donkey Kong", icon: "Charakter-Icons/MK8DX_DK_Icon.png" },
+  { name: "Dry Bones", icon: "Charakter-Icons/MK8DX_Dry_Bones_Icon.png" },
+  { name: "Dry Bowser", icon: "Charakter-Icons/MK8DX_Dry_Bowser_Icon.png" },
+  { name: "Inkling Girl", icon: "Charakter-Icons/MK8DX_Female_Inkling_Icon.png" },
+  { name: "Villager (Female)", icon: "Charakter-Icons/MK8DX_Female_Villager_Icon.png" },
+  { name: "Funky Kong", icon: "Charakter-Icons/MK8DX_Funky_Kong_Icon.png" },
+  { name: "Gold Mario", icon: "Charakter-Icons/MK8DX_Gold_Mario_Icon.png" },
+  { name: "Iggy", icon: "Charakter-Icons/MK8DX_Iggy_Icon.png" },
+  { name: "Isabelle", icon: "Charakter-Icons/MK8DX_Isabelle_Icon.png" },
+  { name: "Kamek", icon: "Charakter-Icons/MK8DX_Kamek_Icon.png" },
+  { name: "King Boo", icon: "Charakter-Icons/MK8DX_King_Boo_Icon.png" },
+  { name: "Koopa Troopa", icon: "Charakter-Icons/MK8DX_Koopa_Troopa_Icon.png" },
+  { name: "Lakitu", icon: "Charakter-Icons/MK8DX_Lakitu_Icon.png" },
+  { name: "Larry", icon: "Charakter-Icons/MK8DX_Larry_Icon.png" },
+  { name: "Lemmy", icon: "Charakter-Icons/MK8DX_Lemmy_Icon.png" },
+  { name: "Link", icon: "Charakter-Icons/MK8DX_Link_Icon.png" },
+  { name: "Ludwig", icon: "Charakter-Icons/MK8DX_Ludwig_Icon.png" },
+  { name: "Luigi", icon: "Charakter-Icons/MK8DX_Luigi_Icon.png" },
+  { name: "Inkling Boy", icon: "Charakter-Icons/MK8DX_Male_Inkling_Icon.png" },
+  { name: "Villager (Male)", icon: "Charakter-Icons/MK8DX_Male_Villager_Icon.png" },
+  { name: "Mario", icon: "Charakter-Icons/MK8DX_Mario_Icon.png" },
+  { name: "Metal Mario", icon: "Charakter-Icons/MK8DX_Metal_Mario_Icon.png" },
+  { name: "Morton", icon: "Charakter-Icons/MK8DX_Morton_Icon.png" },
+  { name: "Pauline", icon: "Charakter-Icons/MK8DX_Pauline_Icon.png" },
+  { name: "Peach", icon: "Charakter-Icons/MK8DX_Peach_Icon.png" },
+  { name: "Peachette", icon: "Charakter-Icons/MK8DX_Peachette_Icon.png" },
+  { name: "Petey Piranha", icon: "Charakter-Icons/MK8DX_Petey_Piranha_Icon.png" },
+  { name: "Pink Gold Peach", icon: "Charakter-Icons/MK8DX_Pink_Gold_Peach_Icon.png" },
+  { name: "Rosalina", icon: "Charakter-Icons/MK8DX_Rosalina_Icon.png" },
+  { name: "Roy", icon: "Charakter-Icons/MK8DX_Roy_Icon.png" },
+  { name: "Shy Guy", icon: "Charakter-Icons/MK8DX_Shy_Guy_Icon.png" },
+  { name: "Tanooki Mario", icon: "Charakter-Icons/MK8DX_Tanooki_Mario_Icon.png" },
+  { name: "Toad", icon: "Charakter-Icons/MK8DX_Toad_Icon.png" },
+  { name: "Toadette", icon: "Charakter-Icons/MK8DX_Toadette_Icon.png" },
+  { name: "Waluigi", icon: "Charakter-Icons/MK8DX_Waluigi_Icon.png" },
+  { name: "Wario", icon: "Charakter-Icons/MK8DX_Wario_Icon.png" },
+  { name: "Wendy", icon: "Charakter-Icons/MK8DX_Wendy_Icon.png" },
+  { name: "Wiggler", icon: "Charakter-Icons/MK8DX_Wiggler_Icon.png" },
+  { name: "Yoshi", icon: "Charakter-Icons/MK8DX_Yoshi_Icon.png" },
 ];
 
 const spinDisplay = document.querySelector("#spinDisplay");
@@ -35,198 +88,18 @@ const assignmentList = document.querySelector("#assignmentList");
 const assignmentTemplate = document.querySelector("#assignmentTemplate");
 const feedback = document.querySelector("#feedback");
 const remaining = document.querySelector("#remaining");
-const rouletteCanvas = document.querySelector("#rouletteCanvas");
-const wheelContext = rouletteCanvas?.getContext("2d");
-
-const WHEEL_BASE_SIZE = 360;
-const wheelColors = [
-  "#ff6b6b",
-  "#ffd93d",
-  "#6ef2b4",
-  "#4dabf7",
-  "#b197fc",
-  "#ffa94d",
-  "#74c0fc",
-  "#f783ac",
-];
-
-let rotation = 0;
-let isSpinning = false;
-let activeFrame = null;
+const characterGrid = document.querySelector("#characterGrid");
 
 let availableCharacters = [...characters];
 const assignments = new Map();
 
-function setupWheelCanvas() {
-  if (!rouletteCanvas || !wheelContext) return;
-
-  const devicePixelRatio = window.devicePixelRatio || 1;
-  rouletteCanvas.width = WHEEL_BASE_SIZE * devicePixelRatio;
-  rouletteCanvas.height = WHEEL_BASE_SIZE * devicePixelRatio;
-  rouletteCanvas.style.width = "100%";
-  rouletteCanvas.style.height = "100%";
-  wheelContext.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
-  drawWheel();
+function normalizeKey(value) {
+  return value.toLowerCase().trim();
 }
 
-function drawWheel(highlightedCharacter = null) {
-  if (!rouletteCanvas || !wheelContext) return;
-
-  const size = WHEEL_BASE_SIZE;
-  const radius = size / 2 - 18;
-  const center = size / 2;
-  const innerRadius = 46;
-  const totalSegments = characters.length;
-  const anglePerSegment = (Math.PI * 2) / totalSegments;
-
-  wheelContext.clearRect(0, 0, size, size);
-
-  wheelContext.save();
-  wheelContext.translate(center, center);
-  wheelContext.rotate(rotation - Math.PI / 2);
-
-  for (let i = 0; i < totalSegments; i++) {
-    const character = characters[i];
-    const startAngle = i * anglePerSegment;
-    const endAngle = startAngle + anglePerSegment;
-    const isAvailable = availableCharacters.includes(character);
-    const isHighlighted = highlightedCharacter && character === highlightedCharacter;
-    const baseColor = wheelColors[i % wheelColors.length];
-    const fillColor = isAvailable ? baseColor : "rgba(80, 84, 128, 0.5)";
-
-    wheelContext.beginPath();
-    wheelContext.moveTo(0, 0);
-    wheelContext.arc(0, 0, radius, startAngle, endAngle);
-    wheelContext.closePath();
-    wheelContext.fillStyle = fillColor;
-    wheelContext.fill();
-
-    if (isHighlighted) {
-      wheelContext.save();
-      wheelContext.clip();
-      const glow = wheelContext.createRadialGradient(0, 0, radius * 0.2, 0, 0, radius);
-      glow.addColorStop(0, "rgba(255, 255, 255, 0.35)");
-      glow.addColorStop(1, "rgba(255, 255, 255, 0)");
-      wheelContext.fillStyle = glow;
-      wheelContext.fillRect(-radius, -radius, radius * 2, radius * 2);
-      wheelContext.restore();
-    }
-
-    wheelContext.strokeStyle = "rgba(6, 9, 30, 0.7)";
-    wheelContext.lineWidth = 2;
-    wheelContext.stroke();
-
-    wheelContext.save();
-    wheelContext.rotate(startAngle + anglePerSegment / 2);
-    wheelContext.translate(radius - 28, 0);
-    wheelContext.rotate(Math.PI / 2);
-    wheelContext.fillStyle = isAvailable ? "#f7f8ff" : "rgba(247, 248, 255, 0.35)";
-    wheelContext.font = "600 13px 'Rubik', sans-serif";
-    wheelContext.textAlign = "center";
-    wheelContext.textBaseline = "middle";
-    wheelContext.fillText(character.name, 0, 0);
-    wheelContext.restore();
-  }
-
-  wheelContext.restore();
-
-  wheelContext.save();
-  wheelContext.translate(center, center);
-  wheelContext.beginPath();
-  wheelContext.arc(0, 0, innerRadius, 0, Math.PI * 2);
-  wheelContext.fillStyle = "rgba(12, 15, 45, 0.92)";
-  wheelContext.fill();
-  wheelContext.lineWidth = 4;
-  wheelContext.strokeStyle = "rgba(255, 255, 255, 0.18)";
-  wheelContext.stroke();
-
-  const centerGradient = wheelContext.createRadialGradient(0, 0, 4, 0, 0, innerRadius);
-  centerGradient.addColorStop(0, "rgba(255, 255, 255, 0.55)");
-  centerGradient.addColorStop(1, "rgba(255, 255, 255, 0)");
-  wheelContext.fillStyle = centerGradient;
-  wheelContext.fill();
-  wheelContext.restore();
-}
-
-function normalizeAngle(angle) {
-  const tau = Math.PI * 2;
-  return ((angle % tau) + tau) % tau;
-}
-
-function targetRotationForCharacter(character) {
-  const totalSegments = characters.length;
-  const index = characters.indexOf(character);
-  const anglePerSegment = (Math.PI * 2) / totalSegments;
-  const segmentCenter = index * anglePerSegment + anglePerSegment / 2;
-  const desired = Math.PI / 2 - segmentCenter;
-  const current = normalizeAngle(rotation);
-  let delta = desired - current;
-  if (delta <= 0) {
-    delta += Math.PI * 2;
-  }
-  const extraSpins = 3 + Math.floor(Math.random() * 2);
-  return rotation + extraSpins * Math.PI * 2 + delta;
-}
-
-function animateRotation(targetRotation, duration = 4200) {
-  return new Promise((resolve) => {
-    const startRotation = rotation;
-    const totalChange = targetRotation - startRotation;
-    const startTime = performance.now();
-
-    function frame(now) {
-      const elapsed = now - startTime;
-      const progress = Math.min(elapsed / duration, 1);
-      const eased = easeOutQuad(progress);
-      rotation = startRotation + totalChange * eased;
-      drawWheel();
-      if (progress < 1) {
-        activeFrame = requestAnimationFrame(frame);
-      } else {
-        activeFrame = null;
-        rotation = normalizeAngle(rotation);
-        drawWheel();
-        resolve();
-      }
-    }
-
-    if (activeFrame) {
-      cancelAnimationFrame(activeFrame);
-    }
-
-    activeFrame = requestAnimationFrame(frame);
-  });
-}
-
-async function spinWheel(finalCharacter) {
-  if (!rouletteCanvas || !wheelContext) {
-    return new Promise((resolve) => {
-      setTimeout(resolve, 1000);
-    });
-  }
-
-  isSpinning = true;
-  spinDisplay.classList.add("is-spinning");
-  const shuffleInterval = setInterval(() => {
-    const preview = pickRandomCharacter();
-    if (preview) {
-      spinDisplay.textContent = preview.name;
-    }
-  }, 90);
-
-  const target = targetRotationForCharacter(finalCharacter);
-  try {
-    await animateRotation(target);
-  } finally {
-    clearInterval(shuffleInterval);
-  }
-
-  drawWheel(finalCharacter);
-  spinDisplay.classList.remove("is-spinning");
-  spinDisplay.classList.add("is-final");
-  spinDisplay.innerHTML = `<span class="display__name">${finalCharacter.name}</span><span class="display__tag">${finalCharacter.tag}</span>`;
-  setTimeout(() => spinDisplay.classList.remove("is-final"), 1200);
-  isSpinning = false;
+function showFeedback(message, isSuccess = false) {
+  feedback.textContent = message;
+  feedback.classList.toggle("is-success", isSuccess);
 }
 
 function updateRemainingText() {
@@ -235,24 +108,49 @@ function updateRemainingText() {
     assignButton.disabled = true;
     playerNameInput.disabled = true;
   } else {
-    remaining.textContent = `${availableCharacters.length} Charaktere sind noch im Item-Block.`;
-    if (!isSpinning) {
-      assignButton.disabled = false;
-      playerNameInput.disabled = false;
-    }
+    remaining.textContent = `${availableCharacters.length} Charaktere sind noch verfügbar.`;
+    assignButton.disabled = false;
+    playerNameInput.disabled = false;
   }
 }
 
-function showFeedback(message, isSuccess = false) {
-  feedback.textContent = message;
-  feedback.classList.toggle("is-success", isSuccess);
+function createCharacterTile(character) {
+  const element = document.createElement("li");
+  element.className = "character-grid__item";
+  element.dataset.character = normalizeKey(character.name);
+  element.innerHTML = `
+    <div class="character-tile">
+      <span class="character-tile__name">${character.name}</span>
+      <img src="${character.icon}" alt="${character.name}" class="character-tile__icon" loading="lazy">
+    </div>
+  `;
+  return element;
+}
+
+function renderCharacterGrid() {
+  const fragment = document.createDocumentFragment();
+  characters.forEach((character) => {
+    fragment.append(createCharacterTile(character));
+  });
+  characterGrid.append(fragment);
+}
+
+function markCharacterAsAssigned(character) {
+  const tile = characterGrid.querySelector(
+    `[data-character="${normalizeKey(character.name)}"]`
+  );
+  if (tile) {
+    tile.classList.add("is-assigned");
+  }
 }
 
 function createAssignmentCard(playerName, character) {
   const element = assignmentTemplate.content.firstElementChild.cloneNode(true);
   element.querySelector(".assignment-card__player").textContent = playerName;
-  element.querySelector(".assignment-card__character").textContent = character.name;
-  element.querySelector(".assignment-card__tagline").textContent = `„${character.tag}“`;
+  element.querySelector(".assignment-card__name").textContent = character.name;
+  const icon = element.querySelector(".assignment-card__icon");
+  icon.src = character.icon;
+  icon.alt = character.name;
   element.style.setProperty("--glow", randomGlow());
   return element;
 }
@@ -270,24 +168,32 @@ function pickRandomCharacter() {
 
 function removeCharacter(target) {
   availableCharacters = availableCharacters.filter((character) => character !== target);
-  drawWheel();
 }
 
-function easeOutQuad(t) {
-  return t * (2 - t);
+function updatePreview(character) {
+  if (!character) {
+    spinDisplay.innerHTML = '<span class="preview__placeholder">?</span>';
+    return;
+  }
+
+  spinDisplay.innerHTML = `
+    <span class="preview__name">${character.name}</span>
+    <img src="${character.icon}" alt="${character.name}" class="preview__icon">
+  `;
 }
 
 function addAssignment(playerName, character) {
-  assignments.set(playerName.toLowerCase(), character.name);
+  assignments.set(normalizeKey(playerName), character.name);
   const card = createAssignmentCard(playerName, character);
   assignmentList.append(card);
 }
 
-async function handleAssignment() {
-  if (isSpinning) {
-    return;
-  }
+function resetForm() {
+  playerNameInput.value = "";
+  playerNameInput.focus();
+}
 
+function handleAssignment() {
   const rawName = playerNameInput.value.trim();
 
   if (!rawName) {
@@ -295,7 +201,8 @@ async function handleAssignment() {
     return;
   }
 
-  if (assignments.has(rawName.toLowerCase())) {
+  const key = normalizeKey(rawName);
+  if (assignments.has(key)) {
     showFeedback("Dieser Spielername hat bereits einen Charakter erhalten.");
     return;
   }
@@ -306,28 +213,13 @@ async function handleAssignment() {
   }
 
   const chosenCharacter = pickRandomCharacter();
-  assignButton.disabled = true;
-  playerNameInput.disabled = true;
-  spinDisplay.textContent = "...";
-  spinDisplay.classList.remove("is-final");
-
-  showFeedback("Item-Block wird geöffnet...", true);
-
-  await spinWheel(chosenCharacter);
-
+  showFeedback(`${rawName} erhält ${chosenCharacter.name}!`, true);
+  updatePreview(chosenCharacter);
   removeCharacter(chosenCharacter);
+  markCharacterAsAssigned(chosenCharacter);
   addAssignment(rawName, chosenCharacter);
   updateRemainingText();
-  showFeedback(`${rawName} erhält ${chosenCharacter.name}!`, true);
-  playerNameInput.value = "";
-  if (availableCharacters.length > 0) {
-    playerNameInput.focus();
-  }
-
-  if (availableCharacters.length === 0) {
-    spinDisplay.textContent = "✔";
-    spinDisplay.classList.remove("is-final");
-  }
+  resetForm();
 }
 
 assignButton.addEventListener("click", handleAssignment);
@@ -338,6 +230,6 @@ playerNameInput.addEventListener("keydown", (event) => {
   }
 });
 
-setupWheelCanvas();
-window.addEventListener("resize", setupWheelCanvas);
+renderCharacterGrid();
+updatePreview();
 updateRemainingText();

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@
     --accent: #7b5bff;
     --accent-dark: #5133ff;
     --text: #f7f8ff;
-    --text-muted: rgba(247, 248, 255, 0.7);
+    --text-muted: rgba(247, 248, 255, 0.72);
     --card-bg: rgba(16, 19, 60, 0.75);
     --card-border: rgba(255, 255, 255, 0.08);
     --success: #6ef2b4;
@@ -29,7 +29,7 @@ body {
     display: flex;
     justify-content: center;
     align-items: center;
-    padding: 2rem;
+    padding: clamp(1.5rem, 3vw, 3rem);
 }
 
 body::before {
@@ -43,8 +43,8 @@ body::before {
 }
 
 .app {
-    width: min(920px, 100%);
-    background-color: rgba(9, 12, 40, 0.8);
+    width: min(1040px, 100%);
+    background-color: rgba(9, 12, 40, 0.82);
     border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 24px;
     box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
@@ -74,173 +74,24 @@ body::before {
     line-height: 1.6;
 }
 
-.roulette {
+.controls {
     display: grid;
-    gap: 1.5rem;
+    gap: clamp(1.5rem, 3vw, 2.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
-.roulette__table {
-    position: relative;
-    display: grid;
-    justify-items: center;
-    gap: 1.2rem;
-    padding: clamp(1.5rem, 4vw, 2.5rem);
-    background: radial-gradient(circle at 50% 20%, rgba(255, 255, 255, 0.18), transparent 60%),
-        linear-gradient(160deg, rgba(21, 25, 70, 0.95), rgba(10, 12, 42, 0.92));
-    border-radius: 24px;
-    border: 2px solid rgba(255, 255, 255, 0.1);
-    box-shadow: inset 0 0 25px rgba(0, 0, 0, 0.45), 0 24px 40px rgba(0, 0, 0, 0.35);
-}
-
-.roulette__table::after {
-    content: "";
-    position: absolute;
-    inset: 14px;
-    border-radius: 18px;
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    pointer-events: none;
-}
-
-.roulette__table-label {
-    font-family: "Press Start 2P", sans-serif;
-    font-size: clamp(0.65rem, 1.6vw, 0.8rem);
-    letter-spacing: 0.24rem;
-    text-transform: uppercase;
-    color: var(--text-muted);
-}
-
-.roulette__wheel-wrapper {
-    position: relative;
-    display: grid;
-    place-items: center;
-    width: min(360px, 70vw);
-    aspect-ratio: 1/1;
-}
-
-.roulette__wheel-wrapper::before {
-    content: "";
-    position: absolute;
-    inset: 6%;
-    border-radius: 50%;
-    border: 10px solid rgba(255, 255, 255, 0.08);
-    box-shadow:
-        inset 0 0 25px rgba(0, 0, 0, 0.65),
-        0 0 35px rgba(0, 0, 0, 0.35);
-    pointer-events: none;
-    z-index: 1;
-}
-
-.roulette__wheel {
-    width: 100%;
-    height: 100%;
-    border-radius: 50%;
-    background: radial-gradient(circle at center, rgba(0, 0, 0, 0.5), transparent 65%);
-    box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.6), 0 0 35px rgba(0, 0, 0, 0.35);
-    position: relative;
-    z-index: 0;
-}
-
-.roulette__pointer {
-    position: absolute;
-    top: -12px;
-    width: 34px;
-    height: 48px;
-    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
-    background: linear-gradient(145deg, var(--primary), var(--primary-dark));
-    border: 2px solid rgba(255, 255, 255, 0.5);
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.45);
-    z-index: 3;
-}
-
-.roulette__pointer::after {
-    content: "";
-    position: absolute;
-    inset: 40% 28%;
-    border-radius: 50%;
-    background: rgba(255, 255, 255, 0.65);
-}
-
-.roulette__item-box {
-    position: relative;
-    background: linear-gradient(145deg, rgba(41, 46, 94, 0.9), rgba(19, 22, 54, 0.85));
+.controls__form,
+.preview {
+    background: linear-gradient(160deg, rgba(21, 25, 70, 0.95), rgba(10, 12, 42, 0.9));
     border-radius: 20px;
-    border: 2px solid rgba(255, 255, 255, 0.1);
-    box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.35), 0 18px 30px rgba(0, 0, 0, 0.35);
-    padding: clamp(1.5rem, 4vw, 2.25rem);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: inset 0 0 25px rgba(0, 0, 0, 0.45), 0 24px 40px rgba(0, 0, 0, 0.3);
+    padding: clamp(1.5rem, 3.5vw, 2.5rem);
     display: grid;
     gap: 1rem;
-    overflow: hidden;
 }
 
-.roulette__item-box::before,
-.roulette__item-box::after {
-    content: "";
-    position: absolute;
-    inset: -80% -30%;
-    background: conic-gradient(from 0deg, rgba(255, 255, 255, 0) 0 120deg, rgba(255, 255, 255, 0.45) 180deg, rgba(255, 255, 255, 0) 240deg);
-    animation: rotate 9s linear infinite;
-    pointer-events: none;
-}
-
-.roulette__item-box::after {
-    animation-duration: 12s;
-    animation-direction: reverse;
-    opacity: 0.7;
-}
-
-.roulette__label {
-    font-family: "Press Start 2P", sans-serif;
-    font-size: clamp(0.6rem, 1.4vw, 0.75rem);
-    color: var(--primary);
-    letter-spacing: 0.2rem;
-}
-
-.roulette__display {
-    font-family: "Press Start 2P", sans-serif;
-    font-size: clamp(1.4rem, 4vw, 2.2rem);
-    text-transform: uppercase;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    gap: 0.6rem;
-    padding: 1.5rem;
-    border-radius: 14px;
-    background: linear-gradient(135deg, rgba(0, 0, 0, 0.28), rgba(255, 255, 255, 0.08));
-    border: 2px solid rgba(255, 255, 255, 0.2);
-    box-shadow: inset 0 4px 16px rgba(255, 255, 255, 0.08), inset 0 -8px 24px rgba(0, 0, 0, 0.5);
-    min-height: clamp(120px, 20vw, 160px);
-    text-align: center;
-    transition: transform 180ms ease, color 200ms ease;
-}
-
-.roulette__display.is-spinning {
-    animation: bounce 0.7s ease-in-out infinite;
-    color: var(--primary);
-}
-
-.display__name {
-    letter-spacing: 0.12rem;
-}
-
-.display__tag {
-    font-family: "Rubik", sans-serif;
-    font-size: clamp(0.85rem, 2vw, 1rem);
-    letter-spacing: normal;
-    color: var(--text-muted);
-    text-transform: none;
-}
-
-.roulette__display.is-final {
-    transform: scale(1.05);
-    color: var(--success);
-}
-
-.roulette__display.is-final .display__tag {
-    color: var(--text-muted);
-}
-
-.roulette__controls {
+.controls__inputs {
     display: grid;
     gap: 0.75rem;
 }
@@ -315,9 +166,131 @@ body::before {
     color: var(--success);
 }
 
+.preview {
+    text-align: center;
+    position: relative;
+}
+
+.preview__label {
+    font-family: "Press Start 2P", sans-serif;
+    font-size: clamp(0.7rem, 1.5vw, 0.85rem);
+    letter-spacing: 0.2rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+}
+
+.preview__display {
+    margin: 0 auto;
+    width: min(240px, 60vw);
+    display: grid;
+    gap: 0.75rem;
+    justify-items: center;
+    background: linear-gradient(135deg, rgba(0, 0, 0, 0.25), rgba(255, 255, 255, 0.08));
+    border-radius: 18px;
+    border: 2px solid rgba(255, 255, 255, 0.14);
+    padding: 1.2rem 1.4rem;
+    box-shadow: inset 0 4px 16px rgba(255, 255, 255, 0.08), inset 0 -8px 24px rgba(0, 0, 0, 0.5);
+    min-height: 220px;
+}
+
+.preview__placeholder {
+    font-family: "Press Start 2P", sans-serif;
+    font-size: 2.2rem;
+    color: var(--text-muted);
+}
+
+.preview__name {
+    font-family: "Press Start 2P", sans-serif;
+    font-size: clamp(0.85rem, 2vw, 1.1rem);
+    letter-spacing: 0.12rem;
+    text-transform: uppercase;
+}
+
+.preview__icon {
+    width: min(160px, 40vw);
+    aspect-ratio: 1/1;
+    object-fit: contain;
+    filter: drop-shadow(0 12px 22px rgba(0, 0, 0, 0.45));
+}
+
 .remaining {
     color: var(--text-muted);
     font-size: 0.95rem;
+}
+
+.character-overview {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.character-overview__title {
+    font-family: "Press Start 2P", sans-serif;
+    font-size: clamp(1rem, 2.4vw, 1.3rem);
+    letter-spacing: 0.14rem;
+    text-transform: uppercase;
+}
+
+.character-grid {
+    list-style: none;
+    display: grid;
+    gap: clamp(1rem, 2.5vw, 1.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.character-grid__item {
+    position: relative;
+    background: rgba(20, 24, 68, 0.7);
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 1.1rem;
+    display: grid;
+    justify-items: center;
+    gap: 0.75rem;
+    transition: transform 150ms ease, border-color 150ms ease, filter 150ms ease;
+}
+
+.character-tile {
+    display: grid;
+    gap: 0.75rem;
+    justify-items: center;
+    width: 100%;
+}
+
+.character-grid__item:hover {
+    transform: translateY(-4px);
+    border-color: rgba(255, 255, 255, 0.2);
+    filter: drop-shadow(0 18px 28px rgba(0, 0, 0, 0.35));
+}
+
+.character-tile__name {
+    font-weight: 600;
+    text-align: center;
+}
+
+.character-tile__icon {
+    width: min(120px, 45vw);
+    aspect-ratio: 1/1;
+    object-fit: contain;
+    border-radius: 12px;
+    background: rgba(0, 0, 0, 0.2);
+    padding: 0.6rem;
+}
+
+.character-grid__item.is-assigned {
+    opacity: 0.35;
+    filter: grayscale(0.9);
+    transform: none;
+}
+
+.character-grid__item.is-assigned::after {
+    content: "Vergeben";
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    font-size: 0.75rem;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
 }
 
 .assignments {
@@ -343,18 +316,19 @@ body::before {
 }
 
 .assignment-card {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
     background: linear-gradient(120deg, rgba(32, 36, 82, 0.9), rgba(20, 23, 58, 0.85));
     border-radius: 16px;
-    padding: 1rem 1.2rem;
+    padding: 1.2rem 1.4rem;
     border: 1px solid rgba(255, 255, 255, 0.1);
     box-shadow:
         0 12px 25px rgba(0, 0, 0, 0.25),
         0 0 30px var(--glow, transparent);
-    overflow: hidden;
+    display: grid;
+    gap: 0.8rem;
+    justify-items: center;
+    text-align: center;
     position: relative;
+    overflow: hidden;
 }
 
 .assignment-card::after {
@@ -366,59 +340,40 @@ body::before {
     pointer-events: none;
 }
 
-.assignment-card__info {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-}
-
 .assignment-card__player {
     font-weight: 600;
     font-size: 1.05rem;
 }
 
-.assignment-card__tagline {
-    font-size: 0.85rem;
-    color: var(--text-muted);
+.assignment-card__character {
+    display: grid;
+    gap: 0.55rem;
+    justify-items: center;
 }
 
-.assignment-card__character {
+.assignment-card__name {
     font-family: "Press Start 2P", sans-serif;
     font-size: clamp(0.75rem, 2vw, 0.95rem);
     text-transform: uppercase;
     letter-spacing: 0.08rem;
 }
 
-@keyframes rotate {
-    from {
-        transform: rotate(0deg);
-    }
-    to {
-        transform: rotate(360deg);
-    }
+.assignment-card__icon {
+    width: min(120px, 45vw);
+    aspect-ratio: 1/1;
+    object-fit: contain;
+    border-radius: 12px;
+    background: rgba(0, 0, 0, 0.25);
+    padding: 0.6rem;
+    filter: drop-shadow(0 12px 22px rgba(0, 0, 0, 0.45));
 }
 
-@keyframes bounce {
-    0%, 100% {
-        transform: scale(1);
-    }
-    50% {
-        transform: scale(1.05);
-    }
-}
-
-@media (max-width: 720px) {
-    body {
-        padding: 1.5rem;
+@media (max-width: 640px) {
+    .controls {
+        grid-template-columns: 1fr;
     }
 
-    .app {
-        padding: 1.8rem;
-    }
-
-    .assignment-card {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0.5rem;
+    .character-grid {
+        grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
     }
 }


### PR DESCRIPTION
## Summary
- remove the roulette UI in favour of a streamlined name input and character preview section
- render all available character icons from the provided folder so that every assignment shows the correct image without nicknames
- refresh the styles for the new overview grid and assignment cards to display icons beneath their names

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e11f6cc8d8832da57428c1c2de0357