### PR TITLE
Remove roulette table frame from character selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,12 +17,9 @@
         </header>
 
         <section class="roulette">
-            <div class="roulette__table" aria-hidden="true">
-                <span class="roulette__table-label">Charakter-Roulette</span>
-                <div class="roulette__wheel-wrapper">
-                    <canvas id="rouletteCanvas" width="360" height="360" class="roulette__wheel" role="img" aria-label="Roulette Tisch mit allen Charakteren"></canvas>
-                    <div class="roulette__pointer" aria-hidden="true"></div>
-                </div>
+            <div class="roulette__wheel-wrapper" aria-hidden="true">
+                <canvas id="rouletteCanvas" width="360" height="360" class="roulette__wheel" role="img" aria-label="Roulette mit allen Charakteren"></canvas>
+                <div class="roulette__pointer" aria-hidden="true"></div>
             </div>
             <div class="roulette__item-box" aria-live="polite" aria-atomic="true">
                 <span class="roulette__label">Nächster Charakter</span>

--- a/style.css
+++ b/style.css
@@ -79,42 +79,14 @@ body::before {
     gap: 1.5rem;
 }
 
-.roulette__table {
-    position: relative;
-    display: grid;
-    justify-items: center;
-    gap: 1.2rem;
-    padding: clamp(1.5rem, 4vw, 2.5rem);
-    background: radial-gradient(circle at 50% 20%, rgba(255, 255, 255, 0.18), transparent 60%),
-        linear-gradient(160deg, rgba(21, 25, 70, 0.95), rgba(10, 12, 42, 0.92));
-    border-radius: 24px;
-    border: 2px solid rgba(255, 255, 255, 0.1);
-    box-shadow: inset 0 0 25px rgba(0, 0, 0, 0.45), 0 24px 40px rgba(0, 0, 0, 0.35);
-}
-
-.roulette__table::after {
-    content: "";
-    position: absolute;
-    inset: 14px;
-    border-radius: 18px;
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    pointer-events: none;
-}
-
-.roulette__table-label {
-    font-family: "Press Start 2P", sans-serif;
-    font-size: clamp(0.65rem, 1.6vw, 0.8rem);
-    letter-spacing: 0.24rem;
-    text-transform: uppercase;
-    color: var(--text-muted);
-}
-
 .roulette__wheel-wrapper {
     position: relative;
     display: grid;
     place-items: center;
     width: min(360px, 70vw);
     aspect-ratio: 1/1;
+    margin: 0 auto;
+    filter: drop-shadow(0 18px 35px rgba(0, 0, 0, 0.45));
 }
 
 .roulette__wheel-wrapper::before {


### PR DESCRIPTION
## Summary
- remove the roulette table container from the character selection layout while keeping the wheel active
- simplify the wheel styling so it appears without the table frame and stays centered in the layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1212df3f0832da9aa0be55c26e80c