### PR TITLE
Passe Breite des Interfaces und Layout der Ziehungskarten an

### DIFF
--- a/style.css
+++ b/style.css
@@ -43,7 +43,7 @@ body::before {
 }
 
 .app {
-    width: min(1280px, 100%);
+    width: min(1440px, 100%);
     background-color: rgba(9, 12, 40, 0.8);
     border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 24px;
@@ -263,18 +263,18 @@ body::before {
 .assignment-list {
     list-style: none;
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: 0.75rem 1rem;
 }
 
 .assignment-card {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
-    gap: 1rem;
+    gap: 0.75rem;
     background: linear-gradient(120deg, rgba(32, 36, 82, 0.9), rgba(20, 23, 58, 0.85));
     border-radius: 16px;
-    padding: 0.75rem 1rem;
+    padding: 0.7rem 0.9rem;
     border: 1px solid rgba(255, 255, 255, 0.1);
     box-shadow:
         0 12px 25px rgba(0, 0, 0, 0.2),
@@ -293,14 +293,16 @@ body::before {
 }
 
 .assignment-card__character {
-    display: flex;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.65rem;
     text-align: left;
+    min-width: 0;
 }
 
 .assignment-card__icon {
-    width: clamp(44px, 6vw, 64px);
+    width: clamp(40px, 5.5vw, 56px);
     aspect-ratio: 1 / 1;
     object-fit: contain;
     filter: drop-shadow(0 6px 10px rgba(0, 0, 0, 0.35));
@@ -308,16 +310,21 @@ body::before {
 
 .assignment-card__name {
     font-family: "Press Start 2P", sans-serif;
-    font-size: clamp(0.7rem, 1.8vw, 0.9rem);
+    font-size: clamp(0.65rem, 1.6vw, 0.85rem);
     text-transform: uppercase;
     letter-spacing: 0.08rem;
+    line-height: 1.3;
+    min-width: 0;
 }
 
 .assignment-card__player {
     font-weight: 600;
-    font-size: 1rem;
-    margin-left: auto;
+    font-size: 0.95rem;
     text-align: right;
+    word-break: break-word;
+    white-space: normal;
+    justify-self: end;
+    min-width: 0;
 }
 
 @keyframes rotate {
@@ -356,18 +363,18 @@ body::before {
     }
 
     .assignment-card {
-        flex-direction: column;
-        align-items: center;
+        grid-template-columns: 1fr;
         text-align: center;
+        gap: 0.9rem;
     }
 
     .assignment-card__character {
-        flex-direction: column;
+        grid-template-columns: 1fr;
+        justify-items: center;
     }
 
     .assignment-card__player {
-        width: 100%;
-        margin-left: 0;
+        justify-self: center;
         text-align: center;
     }
 }


### PR DESCRIPTION
## Summary
- erweitere die maximale Breite der Anwendung und optimiere die Rasteraufteilung
- verbessere die Darstellung der bisherigen Ziehungen mit flexibleren Karten und kleineren Charakterbereichen
- stelle sicher, dass Spielernamen umbrochen werden und auch auf mobilen Geräten sauber dargestellt werden

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1283dddac832d90c43e1e1eeb7bf8