### PR TITLE
Add note about remaining characters under roulette

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
                     <span class="roulette__label">Nächster Charakter</span>
                     <div id="spinDisplay" class="roulette__display">?</div>
                 </div>
+                <p class="roulette__note">73 Charaktere sind noch im Item-Block.</p>
                 <div class="roulette__controls">
                     <label class="input__label" for="playerName">Spielername</label>
                     <input type="text" id="playerName" class="input" placeholder="z.B. Lightning Lisa">

--- a/style.css
+++ b/style.css
@@ -96,6 +96,12 @@ body::before {
     padding-bottom: 1.1rem;
 }
 
+.roulette__note {
+    text-align: center;
+    font-size: 0.95rem;
+    color: var(--text-muted);
+}
+
 .roulette__item-box {
     position: relative;
     background: linear-gradient(145deg, rgba(41, 46, 94, 0.9), rgba(19, 22, 54, 0.85));


### PR DESCRIPTION
## Summary
- add a note under the roulette box to show that 73 characters remain in the item block
- style the note to align with the roulette section visuals

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e134974a9c832da1532b4327438b28