### PR TITLE
Fixiere Hoehe der Roulette-Anzeige

### DIFF
--- a/style.css
+++ b/style.css
@@ -147,11 +147,11 @@ body::before {
     flex-direction: column;
     gap: 0.6rem;
     padding: 1.5rem;
+    height: clamp(220px, 32vw, 260px);
     border-radius: 14px;
     background: linear-gradient(135deg, rgba(0, 0, 0, 0.28), rgba(255, 255, 255, 0.08));
     border: 2px solid rgba(255, 255, 255, 0.2);
     box-shadow: inset 0 4px 16px rgba(255, 255, 255, 0.08), inset 0 -8px 24px rgba(0, 0, 0, 0.5);
-    min-height: clamp(180px, 28vw, 240px);
     text-align: center;
     transition: transform 180ms ease, color 200ms ease;
 }
@@ -170,6 +170,9 @@ body::before {
 
 .display__name {
     letter-spacing: 0.12rem;
+    min-height: 2.6em;
+    display: grid;
+    align-content: center;
 }
 
 .roulette__display.is-final {


### PR DESCRIPTION
## Summary
- klemme die Hoehe der Roulette-Anzeige auf einen festen Bereich, damit darunterliegende Texte nicht mehr springen
- reserviere Platz fuer Charakternamen, um beim Wechsel ein ruhiges Layout zu behalten

## Testing
- nicht ausgefuehrt (nicht automatisiert verifizierbar)


------
https://chatgpt.com/codex/tasks/task_e_68e135dabce0832d94778f5a54741e52