### PR TITLE
Passe Höhe der Ziehungsbox an

### DIFF
--- a/style.css
+++ b/style.css
@@ -273,8 +273,8 @@ body::before {
     flex-direction: column;
     gap: clamp(1.2rem, 2vw, 1.75rem);
     min-height: 0;
-    align-self: flex-start;
-    margin-bottom: clamp(1.2rem, 3vh, 2.4rem);
+    align-self: stretch;
+    height: 100%;
 }
 
 .assignments__title {


### PR DESCRIPTION
## Summary
- lasse die Box der bisherigen Ziehungen bis zur Höhe des Zufalls-Buttons reichen
- entferne den zusätzlichen unteren Abstand und erlaube dem Abschnitt, sich über die volle verfügbare Höhe zu strecken

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e138801c30832dbebde25bd8c4a6b6