### PR TITLE
Adjust assignment history spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -266,6 +266,7 @@ body::before {
     border-radius: 18px;
     border: 1px solid rgba(255, 255, 255, 0.08);
     padding: clamp(1.5rem, 4vw, 2.5rem);
+    padding-bottom: clamp(1.9rem, 4.8vw, 2.9rem);
     box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.2);
     display: flex;
     flex-direction: column;
@@ -273,6 +274,7 @@ body::before {
     min-height: 0;
     align-self: stretch;
     height: 100%;
+    margin-bottom: clamp(0.75rem, 2vw, 1.3rem);
 }
 
 .assignments__title {


### PR DESCRIPTION
## Summary
- increase the bottom padding inside the assignment history panel so the content sits slightly higher
- add a bottom margin to separate the history panel from the surrounding layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e13a3a7ca8832db03fbf70e8c3d401