### PR TITLE
Add draw audio playback with mute control

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,22 @@
                 <div class="roulette__controls">
                     <label class="input__label" for="playerName">Spielername</label>
                     <input type="text" id="playerName" class="input" placeholder="z.B. Lightning Lisa">
-                    <button id="assignButton" class="button">
-                        <span class="button__icon" aria-hidden="true">🎲</span>
-                        Zufall starten
-                    </button>
+                    <div class="roulette__actions">
+                        <button id="assignButton" class="button">
+                            <span class="button__icon" aria-hidden="true">🎲</span>
+                            Zufall starten
+                        </button>
+                        <button
+                            id="soundToggle"
+                            class="sound-toggle"
+                            type="button"
+                            aria-pressed="false"
+                            aria-label="Sound deaktivieren"
+                            title="Sound deaktivieren"
+                        >
+                            <span class="sound-toggle__icon" aria-hidden="true">🔊</span>
+                        </button>
+                    </div>
                 </div>
                 <p id="feedback" class="feedback" role="status"></p>
                 <p id="remaining" class="remaining"></p>
@@ -52,6 +64,7 @@
         </li>
     </template>
 
+    <audio id="spinAudio" src="Sound/mario-kart-wii-item-box-sound-effect-128-ytshorts.savetube.me.mp3" preload="auto"></audio>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -92,9 +92,13 @@ const assignmentList = document.querySelector("#assignmentList");
 const assignmentTemplate = document.querySelector("#assignmentTemplate");
 const feedback = document.querySelector("#feedback");
 const remaining = document.querySelector("#remaining");
+const soundToggle = document.querySelector("#soundToggle");
+const soundToggleIcon = document.querySelector(".sound-toggle__icon");
+const spinAudio = document.querySelector("#spinAudio");
 
 let availableCharacters = [...characters];
 const assignments = new Map();
+let isMuted = false;
 
 function updateAssignmentListLayout() {
   const itemCount = assignmentList.childElementCount;
@@ -147,8 +151,7 @@ function easeOutQuad(t) {
 
 function spinThroughCharacters(finalCharacter) {
   const totalSpins = 26;
-  const baseDelay = 60;
-  const maxAdditionalDelay = 150;
+  const totalDuration = 3000;
 
   spinDisplay.classList.add("is-spinning");
   assignButton.disabled = true;
@@ -157,7 +160,7 @@ function spinThroughCharacters(finalCharacter) {
   for (let i = 0; i < totalSpins; i++) {
     const progress = i / (totalSpins - 1);
     const eased = easeOutQuad(progress);
-    const delay = baseDelay * i + maxAdditionalDelay * eased * i * 0.35;
+    const delay = eased * totalDuration;
 
     setTimeout(() => {
       const current = i === totalSpins - 1 ? finalCharacter : pickRandomCharacter();
@@ -165,15 +168,13 @@ function spinThroughCharacters(finalCharacter) {
     }, delay);
   }
 
-  const totalDuration = baseDelay * totalSpins + maxAdditionalDelay * easeOutQuad(1) * totalSpins * 0.35;
-
   setTimeout(() => {
     spinDisplay.classList.remove("is-spinning");
     spinDisplay.classList.add("is-final");
     setTimeout(() => spinDisplay.classList.remove("is-final"), 1200);
     assignButton.disabled = false;
     playerNameInput.disabled = false;
-  }, totalDuration + 80);
+  }, totalDuration);
 
   return totalDuration;
 }
@@ -217,6 +218,14 @@ function handleAssignment() {
   const chosenCharacter = pickRandomCharacter();
   const animationDuration = spinThroughCharacters(chosenCharacter);
 
+  if (spinAudio) {
+    spinAudio.currentTime = 0;
+    const playPromise = spinAudio.play();
+    if (playPromise !== undefined) {
+      playPromise.catch(() => {});
+    }
+  }
+
   showFeedback("Item-Block wird geöffnet...", true);
 
   setTimeout(() => {
@@ -236,6 +245,29 @@ playerNameInput.addEventListener("keydown", (event) => {
     handleAssignment();
   }
 });
+
+function updateSoundToggle() {
+  if (!soundToggle || !soundToggleIcon || !spinAudio) {
+    return;
+  }
+
+  soundToggle.classList.toggle("is-muted", isMuted);
+  soundToggle.setAttribute("aria-pressed", String(isMuted));
+  const label = isMuted ? "Sound aktivieren" : "Sound deaktivieren";
+  soundToggle.setAttribute("aria-label", label);
+  soundToggle.setAttribute("title", label);
+  soundToggleIcon.textContent = isMuted ? "🔇" : "🔊";
+  spinAudio.muted = isMuted;
+}
+
+if (soundToggle) {
+  soundToggle.addEventListener("click", () => {
+    isMuted = !isMuted;
+    updateSoundToggle();
+  });
+}
+
+updateSoundToggle();
 
 updateRemainingText();
 updateAssignmentListLayout();

--- a/style.css
+++ b/style.css
@@ -183,6 +183,52 @@ body::before {
     gap: 0.75rem;
 }
 
+.roulette__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.sound-toggle {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.35rem;
+    cursor: pointer;
+    transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease, color 120ms ease;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.28);
+}
+
+.sound-toggle:hover,
+.sound-toggle:focus-visible {
+    outline: none;
+    transform: translateY(-2px);
+    box-shadow: 0 18px 28px rgba(0, 0, 0, 0.35);
+    background: rgba(255, 255, 255, 0.16);
+}
+
+.sound-toggle:active {
+    transform: translateY(1px);
+}
+
+.sound-toggle.is-muted {
+    background: rgba(20, 24, 70, 0.85);
+    color: var(--text-muted);
+    box-shadow: none;
+}
+
+.sound-toggle__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .input__label {
     text-transform: uppercase;
     letter-spacing: 0.1rem;


### PR DESCRIPTION
## Summary
- add dedicated audio element that plays during each character draw
- ensure the roulette animation completes in exactly three seconds to match the new sound cue
- provide a mute toggle button and styling so the draw sound can be disabled

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e13b631490832d81c00d987d066b77