### PR TITLE
Improve team drawing button placement and reveal animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,13 +41,13 @@
                         >
                             <span class="sound-toggle__icon" aria-hidden="true">🔊</span>
                         </button>
+                        <button id="startTeamsButton" class="button button--secondary roulette__team-button is-hidden">
+                            <span class="button__icon" aria-hidden="true">👥</span>
+                            Team-Auslosung starten
+                        </button>
                     </div>
                 </div>
                 <p id="feedback" class="feedback" role="status"></p>
-                <button id="startTeamsButton" class="button button--secondary roulette__team-button is-hidden">
-                    <span class="button__icon" aria-hidden="true">👥</span>
-                    Team-Auslosung starten
-                </button>
                 <p id="remaining" class="remaining"></p>
             </section>
 

--- a/script.js
+++ b/script.js
@@ -111,6 +111,7 @@ const playerAssignments = [];
 let teamQueue = [];
 let revealedTeams = [];
 let teamPhaseInitialized = false;
+let teamRevealHighlightTimeout;
 
 function updateAssignmentListLayout() {
   const itemCount = assignmentList.childElementCount;
@@ -325,6 +326,7 @@ function beginTeamPhase() {
 
   if (teamReveal) {
     teamReveal.classList.add("is-empty");
+    teamReveal.classList.remove("team-reveal--active");
     teamReveal.textContent =
       teamQueue.length > 0
         ? "Bereit? Drücke auf \"Nächstes Team ziehen\"!"
@@ -427,7 +429,7 @@ function renderCurrentTeam(team, index) {
   teamReveal.innerHTML = "";
 
   const card = document.createElement("div");
-  card.className = "team-card";
+  card.className = "team-card team-card--enter";
 
   const title = document.createElement("h3");
   title.className = "team-card__title";
@@ -472,10 +474,15 @@ function renderCurrentTeam(team, index) {
   card.append(members);
   teamReveal.append(card);
 
-  teamReveal.style.transform = "scale(1.04)";
-  requestAnimationFrame(() => {
-    teamReveal.style.transform = "scale(1)";
-  });
+  teamReveal.classList.add("team-reveal--active");
+  if (teamRevealHighlightTimeout) {
+    clearTimeout(teamRevealHighlightTimeout);
+  }
+
+  teamRevealHighlightTimeout = setTimeout(() => {
+    teamReveal.classList.remove("team-reveal--active");
+    teamRevealHighlightTimeout = undefined;
+  }, 520);
 }
 
 function appendTeamToList(team, index) {
@@ -520,6 +527,15 @@ function appendTeamToList(team, index) {
 function finalizeTeams() {
   if (drawTeamButton) {
     drawTeamButton.disabled = true;
+  }
+
+  if (teamRevealHighlightTimeout) {
+    clearTimeout(teamRevealHighlightTimeout);
+    teamRevealHighlightTimeout = undefined;
+  }
+
+  if (teamReveal) {
+    teamReveal.classList.remove("team-reveal--active");
   }
 
   if (downloadTeamsButton) {

--- a/style.css
+++ b/style.css
@@ -191,11 +191,21 @@ body::before {
     display: flex;
     align-items: center;
     gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.roulette__actions .button {
+    flex: 1 1 clamp(180px, 45%, 240px);
+}
+
+.roulette__actions .sound-toggle {
+    flex: 0 0 auto;
+    align-self: center;
 }
 
 .roulette__team-button {
     justify-content: center;
-    width: 100%;
+    min-width: clamp(160px, 40%, 220px);
 }
 
 .sound-toggle {
@@ -465,6 +475,8 @@ body::before {
     gap: clamp(1.25rem, 3vw, 2rem);
     position: relative;
     overflow: hidden;
+    min-height: 0;
+    flex: 1 1 auto;
 }
 
 .teams::before {
@@ -517,10 +529,12 @@ body::before {
     padding: 1.2rem;
     border-radius: 16px;
     border: 1px solid rgba(255, 255, 255, 0.12);
-    background: rgba(8, 10, 32, 0.7);
+    background: linear-gradient(145deg, rgba(10, 14, 48, 0.9), rgba(28, 16, 68, 0.75));
     position: relative;
     z-index: 1;
-    transition: transform 220ms ease, box-shadow 220ms ease;
+    overflow: hidden;
+    box-shadow: inset 0 12px 24px rgba(255, 255, 255, 0.04), 0 24px 50px rgba(0, 0, 0, 0.35);
+    transition: transform 260ms ease, box-shadow 260ms ease;
 }
 
 .team-reveal.is-empty {
@@ -530,10 +544,40 @@ body::before {
     font-style: italic;
 }
 
+.team-reveal--active {
+    transform: scale(1.02);
+    box-shadow: inset 0 12px 30px rgba(255, 255, 255, 0.08), 0 26px 55px rgba(0, 0, 0, 0.45), 0 0 45px rgba(123, 91, 255, 0.35);
+}
+
+.team-reveal::before,
+.team-reveal::after {
+    content: "";
+    position: absolute;
+    inset: -60% -20%;
+    background: radial-gradient(circle at 30% 30%, rgba(255, 179, 71, 0.35), transparent 55%);
+    mix-blend-mode: screen;
+    opacity: 0.6;
+    pointer-events: none;
+    animation: energyPulse 14s linear infinite;
+}
+
+.team-reveal::after {
+    inset: -40% -10%;
+    background: radial-gradient(circle at 70% 60%, rgba(123, 91, 255, 0.4), transparent 50%);
+    animation-duration: 18s;
+    animation-direction: reverse;
+}
+
 .team-card {
     display: grid;
     gap: 1rem;
     width: 100%;
+    position: relative;
+    z-index: 1;
+}
+
+.team-card--enter {
+    animation: teamCardEnter 650ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .team-card__title {
@@ -587,6 +631,25 @@ body::before {
     padding-bottom: 0.5rem;
     position: relative;
     z-index: 1;
+    overflow-y: auto;
+    max-height: clamp(240px, 40vh, 420px);
+    padding-right: 0.4rem;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+    min-height: 0;
+}
+
+.team-list::-webkit-scrollbar {
+    width: 6px;
+}
+
+.team-list::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.team-list::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 999px;
 }
 
 .team-list__item {
@@ -641,6 +704,38 @@ body::before {
     }
     50% {
         transform: scale(1.05);
+    }
+}
+
+@keyframes energyPulse {
+    0% {
+        transform: rotate(0deg) scale(1);
+        opacity: 0.55;
+    }
+    50% {
+        transform: rotate(180deg) scale(1.05);
+        opacity: 0.75;
+    }
+    100% {
+        transform: rotate(360deg) scale(1);
+        opacity: 0.55;
+    }
+}
+
+@keyframes teamCardEnter {
+    0% {
+        transform: scale(0.82) translateY(18px);
+        opacity: 0;
+        filter: blur(6px);
+    }
+    55% {
+        transform: scale(1.06) translateY(-6px);
+        opacity: 1;
+        filter: blur(0);
+    }
+    100% {
+        transform: scale(1) translateY(0);
+        opacity: 1;
     }
 }
 


### PR DESCRIPTION
## Summary
- place the team drawing button next to the mute toggle and adjust the action layout
- allow the team overview to scroll and keep the section flexible in height
- add a more dynamic reveal animation with glowing highlights when teams are drawn

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e24372b174832dae57b351c9530311