### PR TITLE
Hide assignment list during team drawing

### DIFF
--- a/script.js
+++ b/script.js
@@ -95,8 +95,10 @@ const remaining = document.querySelector("#remaining");
 const soundToggle = document.querySelector("#soundToggle");
 const soundToggleIcon = document.querySelector(".sound-toggle__icon");
 const spinAudio = document.querySelector("#spinAudio");
+const appRoot = document.querySelector(".app");
 const rouletteSection = document.querySelector(".roulette");
 const teamsSection = document.querySelector(".teams");
+const assignmentsSection = document.querySelector(".assignments");
 const startTeamsButton = document.querySelector("#startTeamsButton");
 const drawTeamButton = document.querySelector("#drawTeamButton");
 const downloadTeamsButton = document.querySelector("#downloadTeamsButton");
@@ -307,12 +309,20 @@ function beginTeamPhase() {
   teamPhaseInitialized = true;
   prepareTeams();
 
+  if (appRoot) {
+    appRoot.classList.add("app--teams");
+  }
+
   if (rouletteSection) {
     rouletteSection.classList.add("is-hidden");
   }
 
   if (teamsSection) {
     teamsSection.classList.remove("is-hidden");
+  }
+
+  if (assignmentsSection) {
+    assignmentsSection.classList.add("is-hidden");
   }
 
   if (startTeamsButton) {

--- a/style.css
+++ b/style.css
@@ -74,6 +74,15 @@ body::before {
     align-items: stretch;
 }
 
+.app--teams .app__layout {
+    grid-template-columns: 1fr;
+}
+
+.app--teams .teams {
+    max-width: min(760px, 100%);
+    margin: 0 auto;
+}
+
 .app__title {
     font-family: "Press Start 2P", "Rubik", sans-serif;
     font-size: clamp(1.4rem, 2.8vw, 1.9rem);


### PR DESCRIPTION
## Summary
- hide the assignments list when switching to the team phase to free up space
- mark the app container during team mode so the layout can collapse to a single column
- center the team section for a wider reveal area

## Testing
- Manual verification (Playwright)

------
https://chatgpt.com/codex/tasks/task_e_68e2b1c7e8c8832d8f61e47f145ec0ad