### PR TITLE
Add suspenseful delay and visuals to team reveal

### DIFF
--- a/style.css
+++ b/style.css
@@ -558,6 +558,65 @@ body::before {
     box-shadow: inset 0 12px 30px rgba(255, 255, 255, 0.08), 0 26px 55px rgba(0, 0, 0, 0.45), 0 0 45px rgba(123, 91, 255, 0.35);
 }
 
+.team-reveal--pending {
+    transform: scale(0.98);
+    box-shadow: inset 0 12px 24px rgba(255, 255, 255, 0.05), 0 18px 40px rgba(0, 0, 0, 0.3);
+}
+
+.team-reveal__countdown {
+    position: relative;
+    display: grid;
+    gap: 0.75rem;
+    justify-items: center;
+    padding: 1.5rem clamp(1.4rem, 4vw, 2.4rem);
+    border-radius: 16px;
+    background: linear-gradient(150deg, rgba(12, 16, 52, 0.88), rgba(58, 26, 104, 0.68));
+    overflow: hidden;
+}
+
+.team-reveal__halo {
+    position: absolute;
+    width: clamp(200px, 30vw, 260px);
+    height: clamp(200px, 30vw, 260px);
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(255, 179, 71, 0.45), rgba(123, 91, 255, 0.28) 55%, rgba(18, 20, 60, 0) 70%);
+    filter: blur(1px);
+    animation: teamRevealHalo 2.6s ease-in-out infinite;
+    opacity: 0.7;
+}
+
+.team-reveal__spinner {
+    width: clamp(64px, 11vw, 86px);
+    aspect-ratio: 1 / 1;
+    border-radius: 50%;
+    border: 3px solid rgba(255, 255, 255, 0.15);
+    border-top-color: var(--primary);
+    border-right-color: rgba(123, 91, 255, 0.85);
+    animation: teamRevealSpinner 0.95s linear infinite;
+    box-shadow: 0 12px 24px rgba(255, 179, 71, 0.2), 0 0 30px rgba(123, 91, 255, 0.25);
+}
+
+.team-reveal__text {
+    position: relative;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-size: clamp(0.9rem, 2.6vw, 1.05rem);
+    color: var(--text);
+    text-shadow: 0 4px 14px rgba(0, 0, 0, 0.4);
+    animation: teamRevealText 1.8s ease-in-out infinite;
+}
+
+.team-reveal__text::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, transparent 0%, rgba(255, 255, 255, 0.6) 45%, transparent 80%);
+    mix-blend-mode: screen;
+    opacity: 0;
+    animation: teamRevealTextShimmer 1.8s ease-in-out infinite;
+}
+
 .team-reveal::before,
 .team-reveal::after {
     content: "";
@@ -745,6 +804,56 @@ body::before {
     100% {
         transform: scale(1) translateY(0);
         opacity: 1;
+    }
+}
+
+@keyframes teamRevealSpinner {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes teamRevealHalo {
+    0% {
+        transform: scale(0.88);
+        opacity: 0.55;
+    }
+    50% {
+        transform: scale(1.05);
+        opacity: 0.85;
+    }
+    100% {
+        transform: scale(0.88);
+        opacity: 0.55;
+    }
+}
+
+@keyframes teamRevealText {
+    0%,
+    100% {
+        letter-spacing: 0.04em;
+        transform: translateY(0);
+    }
+    50% {
+        letter-spacing: 0.08em;
+        transform: translateY(-2px);
+    }
+}
+
+@keyframes teamRevealTextShimmer {
+    0% {
+        opacity: 0;
+        transform: translateX(-120%);
+    }
+    50% {
+        opacity: 0.85;
+    }
+    100% {
+        opacity: 0;
+        transform: translateX(120%);
     }
 }
 


### PR DESCRIPTION
## Summary
- add a two-second suspense delay before revealing the next team
- display an animated countdown state with halo and spinner effects during the delay
- reset pending reveal state when switching phases or finishing the draw

## Testing
- manual via browser

------
https://chatgpt.com/codex/tasks/task_e_68e2b328e628832d90b829358350afae