### PR TITLE
Rework team draw layout and timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,28 +57,35 @@
             </section>
 
             <section class="teams is-hidden" aria-live="polite">
-                <header class="teams__header">
-                    <h2 class="teams__title">Team-Auslosung</h2>
-                    <p id="teamStatus" class="teams__status">
-                        Alle Fahrer sind bereit! Drücke auf den Button, um das nächste Team zu enthüllen.
-                    </p>
-                </header>
-                <div class="teams__controls">
-                    <button id="drawTeamButton" class="button button--secondary">
-                        <span class="button__icon" aria-hidden="true">⚡️</span>
-                        Nächstes Team ziehen
-                    </button>
-                    <button
-                        id="downloadTeamsButton"
-                        class="button button--ghost is-hidden"
-                        type="button"
-                    >
-                        <span class="button__icon" aria-hidden="true">⬇️</span>
-                        Teams herunterladen
-                    </button>
+                <div class="teams__grid">
+                    <div class="teams__reveal-panel">
+                        <header class="teams__header">
+                            <h2 class="teams__title">Team-Auslosung</h2>
+                            <p id="teamStatus" class="teams__status">
+                                Alle Fahrer sind bereit! Drücke auf den Button, um das nächste Team zu enthüllen.
+                            </p>
+                        </header>
+                        <div class="teams__controls">
+                            <button id="drawTeamButton" class="button button--secondary">
+                                <span class="button__icon" aria-hidden="true">⚡️</span>
+                                Nächstes Team ziehen
+                            </button>
+                            <button
+                                id="downloadTeamsButton"
+                                class="button button--ghost is-hidden"
+                                type="button"
+                            >
+                                <span class="button__icon" aria-hidden="true">⬇️</span>
+                                Teams herunterladen
+                            </button>
+                        </div>
+                        <div id="teamReveal" class="team-reveal" aria-live="assertive"></div>
+                    </div>
+                    <aside class="teams__history">
+                        <h3 class="teams__history-title">Bisher ausgeloste Teams</h3>
+                        <ol id="teamList" class="team-list"></ol>
+                    </aside>
                 </div>
-                <div id="teamReveal" class="team-reveal" aria-live="assertive"></div>
-                <ol id="teamList" class="team-list"></ol>
             </section>
         </div>
     </main>

--- a/script.js
+++ b/script.js
@@ -106,7 +106,7 @@ const teamReveal = document.querySelector("#teamReveal");
 const teamStatus = document.querySelector("#teamStatus");
 const teamList = document.querySelector("#teamList");
 
-const TEAM_REVEAL_DELAY = 2000;
+const TEAM_REVEAL_DELAY = 5000;
 
 let availableCharacters = [...characters];
 const assignments = new Map();

--- a/style.css
+++ b/style.css
@@ -408,6 +408,15 @@ body::before {
     .assignments {
         min-height: clamp(240px, 45vh, 360px);
     }
+
+    .teams__grid {
+        grid-template-columns: 1fr;
+        gap: clamp(1.2rem, 4vw, 1.8rem);
+    }
+
+    .teams__history {
+        min-height: clamp(240px, 45vh, 360px);
+    }
 }
 
 .assignment-list::-webkit-scrollbar {
@@ -479,9 +488,6 @@ body::before {
     border-radius: 18px;
     border: 1px solid rgba(255, 255, 255, 0.08);
     padding: clamp(1.5rem, 4vw, 2.5rem);
-    display: flex;
-    flex-direction: column;
-    gap: clamp(1.25rem, 3vw, 2rem);
     position: relative;
     overflow: hidden;
     min-height: 0;
@@ -496,6 +502,24 @@ body::before {
     filter: blur(80px);
     opacity: 0.8;
     pointer-events: none;
+}
+
+.teams__grid {
+    display: grid;
+    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+    gap: clamp(1.35rem, 3.2vw, 2.4rem);
+    height: 100%;
+    align-items: stretch;
+}
+
+.teams__reveal-panel {
+    display: grid;
+    grid-template-rows: auto auto 1fr;
+    gap: clamp(1.1rem, 2.5vw, 1.6rem);
+    position: relative;
+    z-index: 1;
+    min-height: 0;
+    align-content: stretch;
 }
 
 .teams__header {
@@ -529,7 +553,8 @@ body::before {
 }
 
 .team-reveal {
-    min-height: clamp(120px, 15vw, 160px);
+    min-height: clamp(160px, 26vh, 240px);
+    height: 100%;
     display: grid;
     align-content: center;
     justify-items: center;
@@ -561,6 +586,57 @@ body::before {
 .team-reveal--pending {
     transform: scale(0.98);
     box-shadow: inset 0 12px 24px rgba(255, 255, 255, 0.05), 0 18px 40px rgba(0, 0, 0, 0.3);
+}
+
+.teams__history {
+    background: linear-gradient(150deg, rgba(18, 21, 66, 0.9), rgba(10, 12, 38, 0.85));
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 20px 48px rgba(0, 0, 0, 0.32);
+    padding: clamp(1.2rem, 3vw, 1.8rem);
+    display: grid;
+    grid-template-rows: auto 1fr;
+    gap: clamp(1rem, 2.4vw, 1.6rem);
+    position: relative;
+    z-index: 1;
+    min-height: 0;
+}
+
+.teams__history::before,
+.teams__history::after {
+    content: "";
+    position: absolute;
+    pointer-events: none;
+    filter: blur(80px);
+    opacity: 0.8;
+}
+
+.teams__history::before {
+    inset: -45% -35%;
+    background: radial-gradient(circle at 25% 35%, rgba(255, 179, 71, 0.22), transparent 60%);
+}
+
+.teams__history::after {
+    inset: -35% -15%;
+    background: radial-gradient(circle at 70% 65%, rgba(123, 91, 255, 0.28), transparent 60%);
+}
+
+.teams__history-title {
+    font-family: "Press Start 2P", sans-serif;
+    font-size: clamp(0.82rem, 2.1vw, 0.95rem);
+    letter-spacing: 0.16rem;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    text-align: center;
+    position: relative;
+    z-index: 1;
+}
+
+.teams__history .team-list {
+    max-height: none;
+    min-height: 0;
+    height: 100%;
+    padding-right: 0.6rem;
 }
 
 .team-reveal__countdown {


### PR DESCRIPTION
## Summary
- reorganize the team draw section into a two-column layout with a dedicated history panel
- style the new team history card and tweak the reveal panel sizing for better balance
- increase the team reveal countdown to five seconds

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e2b72d7a70832db4d1d0b995d840ee