### PR TITLE
Add modal history for revealed teams

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,15 @@
                                 Nächstes Team ziehen
                             </button>
                             <button
+                                id="showTeamHistoryButton"
+                                class="button button--ghost"
+                                type="button"
+                                disabled
+                            >
+                                <span class="button__icon" aria-hidden="true">🕑</span>
+                                Letzte Teams ansehen
+                            </button>
+                            <button
                                 id="downloadTeamsButton"
                                 class="button button--ghost is-hidden"
                                 type="button"
@@ -81,12 +90,42 @@
                         </div>
                         <div id="teamReveal" class="team-reveal" aria-live="assertive"></div>
                     </div>
-                    <aside class="teams__history">
-                        <h3 class="teams__history-title">Bisher ausgeloste Teams</h3>
-                        <ol id="teamList" class="team-list"></ol>
-                    </aside>
                 </div>
             </section>
+            <div
+                id="teamHistory"
+                class="team-history is-hidden"
+                aria-hidden="true"
+            >
+                <div class="team-history__backdrop" data-team-history-close></div>
+                <div
+                    id="teamHistoryDialog"
+                    class="team-history__dialog"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="teamHistoryTitle"
+                    tabindex="-1"
+                >
+                    <header class="team-history__header">
+                        <h3 id="teamHistoryTitle" class="team-history__title">
+                            Bisher ausgeloste Teams
+                        </h3>
+                        <button
+                            id="closeTeamHistoryButton"
+                            class="team-history__close"
+                            type="button"
+                            aria-label="Team-Historie schließen"
+                            data-team-history-close
+                        >
+                            ✕
+                        </button>
+                    </header>
+                    <p id="teamHistoryEmpty" class="team-history__empty">
+                        Es wurden noch keine Teams ausgelost.
+                    </p>
+                    <ol id="teamList" class="team-list"></ol>
+                </div>
+            </div>
         </div>
     </main>
 

--- a/style.css
+++ b/style.css
@@ -413,10 +413,6 @@ body::before {
         grid-template-columns: 1fr;
         gap: clamp(1.2rem, 4vw, 1.8rem);
     }
-
-    .teams__history {
-        min-height: clamp(240px, 45vh, 360px);
-    }
 }
 
 .assignment-list::-webkit-scrollbar {
@@ -506,7 +502,7 @@ body::before {
 
 .teams__grid {
     display: grid;
-    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+    grid-template-columns: minmax(0, 1fr);
     gap: clamp(1.35rem, 3.2vw, 2.4rem);
     height: 100%;
     align-items: stretch;
@@ -588,51 +584,99 @@ body::before {
     box-shadow: inset 0 12px 24px rgba(255, 255, 255, 0.05), 0 18px 40px rgba(0, 0, 0, 0.3);
 }
 
-.teams__history {
-    background: linear-gradient(150deg, rgba(18, 21, 66, 0.9), rgba(10, 12, 38, 0.85));
-    border-radius: 18px;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    box-shadow: 0 20px 48px rgba(0, 0, 0, 0.32);
-    padding: clamp(1.2rem, 3vw, 1.8rem);
-    display: grid;
-    grid-template-rows: auto 1fr;
-    gap: clamp(1rem, 2.4vw, 1.6rem);
-    position: relative;
-    z-index: 1;
-    min-height: 0;
+.team-history {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(1.5rem, 4vw, 2.5rem);
+    z-index: 20;
 }
 
-.teams__history::before,
-.teams__history::after {
-    content: "";
+.team-history.is-hidden {
+    display: none;
+}
+
+.team-history:not(.is-hidden) {
+    display: flex;
+}
+
+.team-history__backdrop {
     position: absolute;
-    pointer-events: none;
-    filter: blur(80px);
-    opacity: 0.8;
+    inset: 0;
+    background: rgba(5, 6, 20, 0.76);
+    backdrop-filter: blur(6px);
 }
 
-.teams__history::before {
-    inset: -45% -35%;
-    background: radial-gradient(circle at 25% 35%, rgba(255, 179, 71, 0.22), transparent 60%);
+.team-history__dialog {
+    position: relative;
+    width: min(640px, 100%);
+    max-height: min(80vh, 720px);
+    background: linear-gradient(155deg, rgba(11, 12, 38, 0.96), rgba(20, 13, 54, 0.9));
+    border-radius: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 28px 60px rgba(0, 0, 0, 0.45);
+    padding: clamp(1.4rem, 3.5vw, 2.1rem);
+    display: grid;
+    grid-template-rows: auto auto 1fr;
+    gap: clamp(1rem, 2.2vw, 1.5rem);
+    overflow: hidden;
 }
 
-.teams__history::after {
-    inset: -35% -15%;
-    background: radial-gradient(circle at 70% 65%, rgba(123, 91, 255, 0.28), transparent 60%);
+.team-history__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
 }
 
-.teams__history-title {
+.team-history__title {
     font-family: "Press Start 2P", sans-serif;
-    font-size: clamp(0.82rem, 2.1vw, 0.95rem);
+    font-size: clamp(0.9rem, 2.3vw, 1.05rem);
     letter-spacing: 0.16rem;
     text-transform: uppercase;
     color: var(--text-muted);
-    text-align: center;
-    position: relative;
-    z-index: 1;
 }
 
-.teams__history .team-list {
+.team-history__close {
+    border: none;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+    width: 2.4rem;
+    height: 2.4rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.1rem;
+    color: var(--text);
+    cursor: pointer;
+    transition: transform 120ms ease, background 120ms ease, box-shadow 120ms ease;
+}
+
+.team-history__close:hover,
+.team-history__close:focus-visible {
+    outline: none;
+    transform: translateY(-1px);
+    background: rgba(255, 255, 255, 0.16);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.25);
+}
+
+.team-history__close:active {
+    transform: translateY(1px);
+}
+
+.team-history__empty {
+    color: var(--text-muted);
+    text-align: center;
+    font-size: 0.95rem;
+}
+
+.team-history__empty.is-hidden {
+    display: none;
+}
+
+.team-history .team-list {
     max-height: none;
     min-height: 0;
     height: 100%;


### PR DESCRIPTION
## Summary
- add a dedicated modal overlay to review previously revealed teams
- extend the team draw controls and script logic to manage the history button and modal accessibility
- update styling to keep the team reveal area compact while preserving access to past draws

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3a80995cc832d8548878097efbc81