### PR TITLE
Improve team history modal layout and scrolling

### DIFF
--- a/script.js
+++ b/script.js
@@ -352,7 +352,7 @@ function beginTeamPhase() {
   }
 
   if (teamList) {
-    teamList.innerHTML = "";
+    renderTeamHistory();
   }
 
   updateTeamHistoryAvailability();
@@ -418,6 +418,8 @@ function openTeamHistory() {
   if (!teamHistory || !teamHistoryDialog) {
     return;
   }
+
+  renderTeamHistory();
 
   lastFocusedElementBeforeHistory = document.activeElement;
   teamHistory.classList.remove("is-hidden");
@@ -517,7 +519,9 @@ function revealNextTeam() {
     }
 
     renderCurrentTeam(team, revealedTeams.length);
-    appendTeamToList(team, revealedTeams.length);
+    const shouldPreserveScroll =
+      teamHistory && !teamHistory.classList.contains("is-hidden");
+    renderTeamHistory({ preserveScroll: shouldPreserveScroll });
 
     if (drawTeamButton) {
       drawTeamButton.disabled = teamQueue.length === 0;
@@ -605,11 +609,7 @@ function renderCurrentTeam(team, index) {
   }, 520);
 }
 
-function appendTeamToList(team, index) {
-  if (!teamList) {
-    return;
-  }
-
+function createTeamListItem(team, index) {
   const item = document.createElement("li");
   item.className = "team-list__item";
 
@@ -671,8 +671,31 @@ function appendTeamToList(team, index) {
   }
 
   item.append(memberList);
-  teamList.append(item);
+  return item;
+}
+
+function renderTeamHistory({ preserveScroll = false } = {}) {
+  if (!teamList) {
+    return;
+  }
+
+  const previousScrollPosition = teamList.scrollTop;
+  teamList.innerHTML = "";
+
+  const teamsInReverseOrder = [...revealedTeams].reverse();
+
+  teamsInReverseOrder.forEach((team, reverseIndex) => {
+    const actualIndex = revealedTeams.length - reverseIndex;
+    teamList.append(createTeamListItem(team, actualIndex));
+  });
+
   updateTeamHistoryAvailability();
+
+  if (preserveScroll) {
+    teamList.scrollTop = previousScrollPosition;
+  } else {
+    teamList.scrollTop = 0;
+  }
 }
 
 function finalizeTeams() {

--- a/style.css
+++ b/style.css
@@ -612,7 +612,7 @@ body::before {
 .team-history__dialog {
     position: relative;
     width: min(640px, 100%);
-    max-height: min(80vh, 720px);
+    max-height: min(90vh, 780px);
     background: linear-gradient(155deg, rgba(11, 12, 38, 0.96), rgba(20, 13, 54, 0.9));
     border-radius: 20px;
     border: 1px solid rgba(255, 255, 255, 0.1);
@@ -621,7 +621,7 @@ body::before {
     display: grid;
     grid-template-rows: auto auto 1fr;
     gap: clamp(1rem, 2.2vw, 1.5rem);
-    overflow: hidden;
+    overflow: auto;
 }
 
 .team-history__header {
@@ -681,6 +681,9 @@ body::before {
     min-height: 0;
     height: 100%;
     padding-right: 0.6rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: clamp(1rem, 2.2vw, 1.4rem);
+    align-content: start;
 }
 
 .team-reveal__countdown {


### PR DESCRIPTION
## Summary
- render the team history list from all revealed teams so the newest teams appear first
- adjust the team history modal layout to support scrolling and a multi-column grid for better overview

## Testing
- Manual test via automated browser script creating teams and opening the history dialog

------
https://chatgpt.com/codex/tasks/task_e_68e3ae6c13bc832dafd7c6ac11ffc0c3