### PR TITLE
Add back to roulette button and improve team history layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,14 @@
                                 <span class="button__icon" aria-hidden="true">⬇️</span>
                                 Teams herunterladen
                             </button>
+                            <button
+                                id="backToRouletteButton"
+                                class="button button--ghost"
+                                type="button"
+                            >
+                                <span class="button__icon" aria-hidden="true">↩️</span>
+                                Zurück zum Roulette
+                            </button>
                         </div>
                         <div id="teamReveal" class="team-reveal" aria-live="assertive"></div>
                     </div>

--- a/script.js
+++ b/script.js
@@ -106,6 +106,7 @@ const teamReveal = document.querySelector("#teamReveal");
 const teamStatus = document.querySelector("#teamStatus");
 const teamList = document.querySelector("#teamList");
 const showTeamHistoryButton = document.querySelector("#showTeamHistoryButton");
+const backToRouletteButton = document.querySelector("#backToRouletteButton");
 const teamHistory = document.querySelector("#teamHistory");
 const teamHistoryDialog = document.querySelector("#teamHistoryDialog");
 const teamHistoryEmpty = document.querySelector("#teamHistoryEmpty");
@@ -308,6 +309,10 @@ if (showTeamHistoryButton) {
   showTeamHistoryButton.addEventListener("click", openTeamHistory);
 }
 
+if (backToRouletteButton) {
+  backToRouletteButton.addEventListener("click", returnToRoulette);
+}
+
 teamHistoryCloseButtons.forEach((button) => {
   button.addEventListener("click", closeTeamHistory);
 });
@@ -387,6 +392,70 @@ function beginTeamPhase() {
   if (downloadTeamsButton) {
     downloadTeamsButton.addEventListener("click", downloadTeams);
   }
+}
+
+function returnToRoulette() {
+  closeTeamHistory();
+
+  if (pendingTeamRevealTimeout) {
+    clearTimeout(pendingTeamRevealTimeout);
+    pendingTeamRevealTimeout = undefined;
+  }
+
+  if (teamRevealHighlightTimeout) {
+    clearTimeout(teamRevealHighlightTimeout);
+    teamRevealHighlightTimeout = undefined;
+  }
+
+  teamQueue = [];
+  revealedTeams = [];
+  teamPhaseInitialized = false;
+
+  if (teamReveal) {
+    teamReveal.innerHTML = "";
+    teamReveal.classList.add("is-empty");
+    teamReveal.classList.remove("team-reveal--active");
+    teamReveal.classList.remove("team-reveal--pending");
+    teamReveal.textContent =
+      playerAssignments.length > 1
+        ? "Bereit? Drücke auf \"Nächstes Team ziehen\"!"
+        : "Es konnten keine vollständigen Teams gebildet werden.";
+  }
+
+  if (teamStatus) {
+    teamStatus.textContent =
+      "Alle Fahrer sind bereit! Drücke auf den Button, um das nächste Team zu enthüllen.";
+  }
+
+  if (downloadTeamsButton) {
+    downloadTeamsButton.classList.add("is-hidden");
+    downloadTeamsButton.disabled = true;
+  }
+
+  if (drawTeamButton) {
+    drawTeamButton.disabled = false;
+  }
+
+  renderTeamHistory();
+
+  if (appRoot) {
+    appRoot.classList.remove("app--teams");
+  }
+
+  if (rouletteSection) {
+    rouletteSection.classList.remove("is-hidden");
+  }
+
+  if (teamsSection) {
+    teamsSection.classList.add("is-hidden");
+  }
+
+  if (assignmentsSection) {
+    assignmentsSection.classList.remove("is-hidden");
+  }
+
+  updateTeamStartAvailability();
+  updateTeamHistoryAvailability();
 }
 
 function updateTeamStartAvailability() {

--- a/style.css
+++ b/style.css
@@ -616,7 +616,7 @@ body::before {
     display: grid;
     grid-template-rows: auto auto 1fr;
     gap: clamp(1rem, 2.2vw, 1.5rem);
-    overflow: auto;
+    overflow: hidden;
 }
 
 .team-history__header {
@@ -679,6 +679,8 @@ body::before {
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: clamp(1rem, 2.2vw, 1.4rem);
     align-content: start;
+    overflow-y: auto;
+    scrollbar-width: thin;
 }
 
 .team-reveal__countdown {


### PR DESCRIPTION
## Summary
- add a "Zurück zum Roulette" button in the team controls to return to the roulette view for additional players
- reset the team phase state when returning so future team draws start fresh and the download/history buttons update correctly
- adjust the team history dialog styling so long lists scroll instead of being clipped

## Testing
- Manual testing in browser

------
https://chatgpt.com/codex/tasks/task_e_68e3c0123c14832dabc92f62bcb8a19a