### PR TITLE
Fix team history list overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -617,6 +617,21 @@ body::before {
     grid-template-rows: auto auto 1fr;
     gap: clamp(1rem, 2.2vw, 1.5rem);
     overflow: hidden;
+    overflow-y: auto;
+    scrollbar-width: thin;
+}
+
+.team-history__dialog::-webkit-scrollbar {
+    width: 6px;
+}
+
+.team-history__dialog::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.team-history__dialog::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 999px;
 }
 
 .team-history__header {
@@ -674,13 +689,16 @@ body::before {
 .team-history .team-list {
     max-height: none;
     min-height: 0;
-    height: 100%;
+    height: auto;
     padding-right: 0.6rem;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    display: flex;
+    flex-direction: column;
     gap: clamp(1rem, 2.2vw, 1.4rem);
-    align-content: start;
-    overflow-y: auto;
+    align-content: stretch;
+    align-items: stretch;
     scrollbar-width: thin;
+    overflow: visible;
+    overflow-y: visible;
 }
 
 .team-reveal__countdown {
@@ -849,7 +867,6 @@ body::before {
     gap: 1rem;
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.28);
     position: relative;
-    overflow: hidden;
 }
 
 .team-list__item::before {


### PR DESCRIPTION
## Summary
- allow the team history list to expand without clipping players
- let the modal handle scrolling so team entries remain fully visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d008a97c832db40b85f804a434ab