### PR TITLE
Add live player count summary under assignment list

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
             <section class="assignments" aria-live="polite">
                 <h2 class="assignments__title">Bisherige Ziehungen</h2>
                 <ul id="assignmentList" class="assignment-list"></ul>
+                <p id="playerCount" class="assignments__summary" aria-live="polite"></p>
             </section>
 
             <section class="teams is-hidden" aria-live="polite">

--- a/script.js
+++ b/script.js
@@ -92,6 +92,7 @@ const assignmentList = document.querySelector("#assignmentList");
 const assignmentTemplate = document.querySelector("#assignmentTemplate");
 const feedback = document.querySelector("#feedback");
 const remaining = document.querySelector("#remaining");
+const playerCountDisplay = document.querySelector("#playerCount");
 const soundToggle = document.querySelector("#soundToggle");
 const soundToggleIcon = document.querySelector(".sound-toggle__icon");
 const spinAudio = document.querySelector("#spinAudio");
@@ -129,6 +130,22 @@ function updateAssignmentListLayout() {
   const itemCount = assignmentList.childElementCount;
   const visibleItems = Math.max(1, Math.min(itemCount, 5));
   assignmentList.style.setProperty("--visible-items", visibleItems);
+}
+
+function updatePlayerCount() {
+  if (!playerCountDisplay) {
+    return;
+  }
+
+  const count = playerAssignments.length;
+
+  if (count === 0) {
+    playerCountDisplay.textContent = "Noch keine Spieler:innen gezogen.";
+    return;
+  }
+
+  const label = count === 1 ? "Spieler:in" : "Spieler:innen";
+  playerCountDisplay.textContent = `Insgesamt ${count} ${label} im Rennen.`;
 }
 
 function updateRemainingText() {
@@ -222,6 +239,7 @@ function addAssignment(playerName, character) {
     characterIcon: character.icon,
   });
   updateAssignmentListLayout();
+  updatePlayerCount();
   updateTeamStartAvailability();
   requestAnimationFrame(() => {
     assignmentList.scrollTo({ top: assignmentList.scrollHeight, behavior: "smooth" });
@@ -321,6 +339,7 @@ updateSoundToggle();
 
 updateRemainingText();
 updateAssignmentListLayout();
+updatePlayerCount();
 updateTeamStartAvailability();
 updateTeamHistoryAvailability();
 

--- a/style.css
+++ b/style.css
@@ -372,6 +372,13 @@ body::before {
     text-align: center;
 }
 
+.assignments__summary {
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    min-height: 1.4rem;
+}
+
 .assignment-list {
     --visible-items: 5;
     --card-gap: 0.9rem;


### PR DESCRIPTION
## Summary
- add a summary element below the previous draws list to display the total number of players
- style the summary text to match the existing assignments panel layout
- update the roulette logic to keep the player count message in sync with new draws

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3e141bfcc832dbc9e52f43451b78b